### PR TITLE
Add IS-07 related transports and indicate specification applicability

### DIFF
--- a/device-control-types/README.md
+++ b/device-control-types/README.md
@@ -7,7 +7,7 @@ This Device Control Types parameter register contains values that may be used to
 - Values used for the control 'type' property are not required to be included in this parameter register.
 - Each entry MUST define a unique control type name (which is a URN).
 - Each entry MUST have a short description and include contact information for the proponent(s).
-- Each entry SHOULD provide a link to a specification for the control type, as well as identifying the AMWA IS-04 API Versions for which the entry is applicable.
+- Each entry SHOULD provide a link to a specification for the control type, as well as identifying any AMWA Specifications and versions for which the entry is applicable.
 - In the case of substantial revision to the control specification, a new control type name MUST be defined. Using versioned names is therefore RECOMMENDED.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
@@ -17,7 +17,9 @@ This Device Control Types parameter register contains values that may be used to
   - **Description:** Identifies the Connection API v1.0.
   - **Proponent:** [AMWA](https://github.com/AMWA-TV)
   - **Specification:** [AMWA IS-05 NMOS Device Connection Management v1.0](https://github.com/AMWA-TV/nmos-device-connection-management/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.2+
 - **Name:** urn:x-nmos:control:manifest-base/v1.0
   - **Description:** Use of this control type provides redundant locators for sender transport files (also known as manifests).
   - **Proponent:** [Sony](https://github.com/sony) (contact [@garethsb-sony](https://github.com/garethsb-sony))
   - **Specification:** [Manifest Base URL](manifest-base.md)
+  - **Applicability:** AMWA IS-04 v1.1+

--- a/device-types/README.md
+++ b/device-types/README.md
@@ -7,7 +7,7 @@ This Device Types parameter register contains values that may be used to identif
 - Values used for the device 'type' property are not required to be included in this parameter register.
 - Each entry MUST define a unique device type name (which is a URN).
 - Each entry MUST have a short description and include contact information for the proponent(s).
-- Each entry SHOULD provide a link to a specification for the device type, as well as identifying the AMWA IS-04 API Versions for which the entry is applicable.
+- Each entry SHOULD provide a link to a specification for the device type, as well as identifying any AMWA Specifications and versions for which the entry is applicable.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
 Manufacturers MAY use their own namespaces to indicate device types which are not currently defined within the NMOS namespace.
@@ -18,7 +18,9 @@ Manufacturers MAY use their own namespaces to indicate device types which are no
   - **Description:** Generic device.
   - **Proponent:** [AMWA](https://github.com/AMWA-TV)
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.1+
 - **Name:** urn:x-nmos:device:pipeline
   - **Description:** Pipeline device.
   - **Proponent:** [AMWA](https://github.com/AMWA-TV)
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.1+

--- a/device-types/README.md
+++ b/device-types/README.md
@@ -10,7 +10,7 @@ This Device Types parameter register contains values that may be used to identif
 - Each entry SHOULD provide a link to a specification for the device type, as well as identifying the AMWA IS-04 API Versions for which the entry is applicable.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
-Manufacturers MAY use their own namespaces to indicate device types which are not defined within the NMOS namespace at a particular API version, but should support be added in a future version the NMOS variant MUST be used when upgrading to that API version.
+Manufacturers MAY use their own namespaces to indicate device types which are not currently defined within the NMOS namespace.
 
 ## Values
 

--- a/formats/README.md
+++ b/formats/README.md
@@ -7,7 +7,7 @@ This Formats parameter register contains values that may be used to identify a d
 - Values used for the 'format' property are defined only by revisions of AMWA IS-04 itself.
 - Each entry MUST define a unique format name (which is a URN).
 - Each entry MUST have a short description.
-- Each entry MUST identify the AMWA IS-04 API Version from which it is valid.
+- Each entry MUST identify any AMWA Specifications and versions from which it is valid.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
 Query API clients MUST be tolerant to the presence of formats not yet defined here which may be added in later API versions.
@@ -17,12 +17,16 @@ Query API clients MUST be tolerant to the presence of formats not yet defined he
 - **Name:** urn:x-nmos:format:video
   - **Description:** Identifies (sources of) video flows.
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.0+
 - **Name:** urn:x-nmos:format:audio
   - **Description:** Identifies (sources of) audio flows.
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.0+
 - **Name:** urn:x-nmos:format:data
   - **Description:** Identifies (sources of) data flows.
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.0+
 - **Name:** urn:x-nmos:format:mux
   - **Description:** Identifies (sources of) multiplexed flows.
   - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+

--- a/node-service-types/README.md
+++ b/node-service-types/README.md
@@ -7,7 +7,7 @@ This Node Service Types parameter register contains values that may be used to i
 - Values used for the service 'type' property are not required to be included in this parameter register.
 - Each entry MUST define a unique service type name (which is a URN).
 - Each entry MUST have a short description and include contact information for the proponent(s).
-- Each entry SHOULD provide a link to a specification for the service type, as well as identifying the AMWA IS-04 API Versions for which the entry is applicable.
+- Each entry SHOULD provide a link to a specification for the service type, as well as identifying any AMWA Specifications and versions for which the entry is applicable.
 - In the case of substantial revision to the service specification, a new service type name MUST be defined. Using versioned names is therefore RECOMMENDED.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
@@ -20,3 +20,4 @@ This Node Service Types parameter register contains values that may be used to i
   - **Description:** This API provides a zeroconf/HTTP bridge for NMOS service types.
   - **Proponent:** [BBC](https://github.com/bbc) (contact [@simonrankine](https://github.com/simonrankine))
   - **Specification:** [NMOS MDNS Bridge](https://github.com/bbc/nmos-mdns-bridge)
+  - **Applicability:** AMWA IS-04 v1.0+

--- a/tags/README.md
+++ b/tags/README.md
@@ -7,7 +7,7 @@ Parameter register contains values that may be used to expose some reserved tags
 ## Criteria
 
 - Each entry MUST have a short description and include contact information for the proponent(s).
-- Each entry SHOULD provide a link to a specification for the tag usage, as well as identifying the AMWA IS-04 API Versions for which the entry is applicable.
+- Each entry SHOULD provide a link to a specification for the tag usage, as well as identifying any AMWA Specifications and versions for which the entry is applicable.
 - In the case of substantial revision to the tag specification, a new tag type name MUST be defined. Using versioned names is therefore RECOMMENDED when this applies.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
@@ -17,3 +17,4 @@ Parameter register contains values that may be used to expose some reserved tags
   - **Description:** Group tag that can be used in a JSON description for an NMOS resource v1.0.
   - **Proponent:** [Grass Valley, a Belden brand](http://grassvalley.com/) (contact [Serge Grondin](https://github.com/sagrondin))
   - **Specification:** [Group Hint tags](grouphint.md)
+  - **Applicability:** AMWA IS-04 v1.0+

--- a/transports/README.md
+++ b/transports/README.md
@@ -26,5 +26,11 @@ Manufacturers MAY use their own namespaces to indicate transports which are not 
 - **Name:** urn:x-nmos:transport:dash
   - **Description:** Identifies the Dynamic Adaptive Streaming over HTTP technology.
   - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+- **Name:** urn:x-nmos:transport:mqtt
+  - **Description:** Identifies Message Queueing Telemetry Transport (MQTT).
+  - **Specification:** [AMWA IS-05 v1.1](https://github.com/AMWA-TV/nmos-device-connection-management/tree/v1.1-dev)
+- **Name:** urn:x-nmos:transport:websocket
+  - **Description:** Identifies the WebSocket transport type.
+  - **Specification:** [AMWA IS-05 v1.1](https://github.com/AMWA-TV/nmos-device-connection-management/tree/v1.1-dev)
 
 Note: An RTP Transmitter sending to a multicast group should use the transport 'urn:x-nmos:transport:rtp.mcast', but a receiver supporting both unicast and multicast should present the transport 'urn:x-nmos:transport:rtp' to indicate its less restrictive state.

--- a/transports/README.md
+++ b/transports/README.md
@@ -10,7 +10,7 @@ This Transports parameter register contains values that may be used to identify 
 - Each entry SHOULD provide a link to a specification for the transport, as well as identifying the AMWA IS-04 API Versions for which the entry is applicable.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
-Manufacturers MAY use their own namespaces to indicate transports which are not defined within the NMOS namespace at a particular API version, but should support be added in a future version the NMOS variant MUST be used when upgrading to that API version.
+Manufacturers MAY use their own namespaces to indicate transports which are not currently defined within the NMOS namespace.
 
 ## Values
 

--- a/transports/README.md
+++ b/transports/README.md
@@ -7,7 +7,7 @@ This Transports parameter register contains values that may be used to identify 
 - Values used for the 'transport' property are not required to be included in this parameter register.
 - Each entry MUST define a unique transport name (which is a URN).
 - Each entry MUST have a short description.
-- Each entry SHOULD provide a link to a specification for the transport, as well as identifying the AMWA IS-04 API Versions for which the entry is applicable.
+- Each entry SHOULD provide a link to a specification for the transport, as well as identifying any AMWA Specifications and versions for which the entry is applicable.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
 Manufacturers MAY use their own namespaces to indicate transports which are not currently defined within the NMOS namespace.
@@ -17,20 +17,26 @@ Manufacturers MAY use their own namespaces to indicate transports which are not 
 - **Name:** urn:x-nmos:transport:rtp
   - **Description:** Identifies the Real-time Transport Protocol.
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.0+, IS-05 v1.0+
 - **Name:** urn:x-nmos:transport:rtp.mcast
   - **Description:** Identifies RTP multicast.
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.0+, IS-05 v1.0+
 - **Name:** urn:x-nmos:transport:rtp.ucast
   - **Description:** Identifies RTP unicast.
   - **Specification:** [AMWA IS-04 v1.0](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.0.x)
+  - **Applicability:** AMWA IS-04 v1.0+, IS-05 v1.0+
 - **Name:** urn:x-nmos:transport:dash
   - **Description:** Identifies the Dynamic Adaptive Streaming over HTTP technology.
   - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+, IS-05 v1.0+
 - **Name:** urn:x-nmos:transport:mqtt
   - **Description:** Identifies Message Queueing Telemetry Transport (MQTT).
   - **Specification:** [AMWA IS-05 v1.1](https://github.com/AMWA-TV/nmos-device-connection-management/tree/v1.1-dev)
+  - **Applicability:** AMWA IS-04 v1.3+, IS-05 v1.1+, IS-07 v1.0+
 - **Name:** urn:x-nmos:transport:websocket
   - **Description:** Identifies the WebSocket transport type.
   - **Specification:** [AMWA IS-05 v1.1](https://github.com/AMWA-TV/nmos-device-connection-management/tree/v1.1-dev)
+  - **Applicability:** AMWA IS-04 v1.3+, IS-05 v1.1+, IS-07 v1.0+
 
 Note: An RTP Transmitter sending to a multicast group should use the transport 'urn:x-nmos:transport:rtp.mcast', but a receiver supporting both unicast and multicast should present the transport 'urn:x-nmos:transport:rtp' to indicate its less restrictive state.


### PR DESCRIPTION
This PR adds:
* Transport type definitions for MQTT and WebSocket
* Applicability lines to indicate specifications which make use of any given parameter
* Relax linking of transport/device types to specification versions (matches a proposed change for IS-04 v1.3 to avoid having to tie transport/device types to IS-04 API versions)

I'd suggest that this needs a review, and perhaps shouldn't be merged until the related changes to IS-04/05 are at least merged into their corresponding -dev branches.