### PR TITLE
Add a parameter register for IS-04 Sources and Flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The following parameter registers are maintained:
 - [NMOS Transports](transports/)
 - [NMOS Device Types](device-types/)
 - [NMOS Tags](tags/)
+- [NMOS Source Attributes](source-attributes/)
+- [NMOS Flow Attributes](flow-attributes/)
 
 Each parameter register defines specific criteria and considerations for when and how values can be included, and identifies the procedures for revision and deprecation of entries.
 

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -79,3 +79,67 @@ Clients should be aware that requesting data about a very broad 'media\_type' ma
 ### Relating to urn:x-nmos:format:mux
 
 - No parameters currently defined
+
+## Common Examples
+
+The following examples are noted to highlight the breadth of content which may be represented using these attributes.
+
+### Video
+
+**Raw Video** (including ST.2110-20 and RFC4175 when sent as RTP)
+* format: urn:x-nmos:format:video
+* media\_type: video/raw
+
+**Coded Video** (including ST.2110-22 when sent as RTP)
+* format: urn:x-nmos:format:video
+* media\_type: Various, including video/H264 and video/vc2
+
+**MPEG 4 Transport Streams** (containing video only)
+* format: urn:x-nmos:format:video
+* media\_type: video/mpeg4-generic
+
+### Audio
+
+**Raw Audio** (including ST.2110-30 and AES67 when sent as RTP)
+* format: urn:x-nmos:format:audio
+* media\_type: Various, including audio/L24
+
+**Coded Audio**
+* format: urn:x-nmos:format:audio
+* media\_type: Various, including audio/opus
+
+**AES3 Encapsulated Audio** (including ST.2110-31 when sent as RTP)
+* format: urn:x-nmos:format:audio
+* media\_type: audio/AM824
+
+**MPEG 4 Transport Streams** (containing audio only)
+* format: urn:x-nmos:format:audio
+* media\_type: audio/mpeg4-generic
+
+### Data
+
+**ST.291 Ancillary Data**
+* format: urn:x-nmos:format:data
+* media\_type: video/smpte291
+
+**JSON Data**
+* format: urn:x-nmos:format:data
+* media\_type: application/json
+
+**MPEG 4 Transport Streams** (containing data only)
+* format: urn:x-nmos:format:data
+* media\_type: application/mpeg4-generic
+
+### Mux
+
+**MPEG 2 Transport Streams** (containing mixed formats)
+* format: urn:x-nmos:format:mux
+* media\_type: video/MP2T
+
+**MPEG 4 Transport Streams** (containing mixed formats)
+* format: urn:x-nmos:format:mux
+* media\_type: video/mpeg4-generic
+
+**SMPTE 2022-6**
+* format: urn:x-nmos:format:mux
+* media\_type: video/SMPTE2022-6

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -1,0 +1,79 @@
+# NMOS Flow Attributes
+
+This Flow Attributes parameter register contains values that may be used to identify specific types of content which may be advertised via flow resources defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://github.com/AMWA-TV/nmos-discovery-registration).
+
+## Criteria
+
+- Each entry MUST be associated with an existing defined [NMOS Format](../formats) and a media_type.
+- Each entry MUST define a unique attribute name within the scope of a Flow.
+- Each entry MUST have a short description.
+- Each entry MUST identify any AMWA Specifications and versions from which it is valid.
+- Each entry MUST link to a schema definition held within this repository.
+- Where linked schemas contain an 'enum' these MAY be expanded over time. Implementations MUST NOT strictly validate against the limited set of permitted values provided in these schemas.
+- Schemas MUST NOT have required attributes removed following their inclusion in this register.
+- Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
+
+Query API clients from v1.3 of IS-04 onwards MUST be tolerant to the presence of Flow attributes not yet defined here which may be added in later API versions.
+
+## Values
+
+### Relating to urn:x-nmos:format:video
+
+- **Name:** frame_width
+  - **Description:** Width of the picture in pixels.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+- **Name:** frame_height
+  - **Description:** Height of the picture in pixels.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+- **Name:** interlace_mode
+  - **Description:** Interlace video mode for frames in this Flow.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+- **Name:** colorspace
+  - **Description:** Colorspace used for the video.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+- **Name:** transfer_characteristic
+  - **Description:** Transfer characteristic.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+
+#### Relating to raw video, identified by 'video/raw'
+
+- **Name:** components
+  - **Description:** Array of objects describing the video components.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+
+### Relating to urn:x-nmos:format:audio
+
+- **Name:** sample_rate
+  - **Description:** Number of audio samples per second for this Flow
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+- **Name:** bit_depth
+  - **Description:** Bit depth of the audio samples. Intended for use by raw audio Flows only
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+
+### Relating to urn:x-nmos:format:data
+
+#### Relating to SDI ancillary, identified by 'video/smpte291'
+
+- **Name:** DID_SDID
+  - **Description:** List of Data identification and Secondary data identification words.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+
+#### Relating to JSON data, identified by 'application/json'
+
+- **Name:** event_type
+  - **Description:** Identifies a sub-classification of event data which is being produced, as required for AMWA IS-07
+  - **Specification:** [AMWA IS-04 v1.3](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.3-dev)
+  - **Applicability:** AMWA IS-04 v1.3+
+
+### Relating to urn:x-nmos:format:mux
+
+- No parameters currently defined

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -4,7 +4,7 @@ This Flow Attributes parameter register contains values that may be used to iden
 
 ## Criteria
 
-- Each entry MUST be associated with an existing defined [NMOS Format](../formats) and a media_type.
+- Each entry MUST be associated with an existing defined [NMOS Format](../formats) and a media\_type.
 - Each entry MUST define a unique attribute name within the scope of a Flow.
 - Each entry MUST have a short description.
 - Each entry MUST identify any AMWA Specifications and versions from which it is valid.
@@ -14,6 +14,8 @@ This Flow Attributes parameter register contains values that may be used to iden
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
 
 Query API clients from v1.3 of IS-04 onwards MUST be tolerant to the presence of Flow attributes not yet defined here which may be added in later API versions.
+
+Clients should be aware that requesting data about a very broad 'media\_type' may return more results than are expected. For example, a media\_type of 'application/json' is likely to be used by more than just IS-07 Flows. In this specific example case, use of the 'event_type' attribute can aid in differentiation.
 
 ## Values
 

--- a/source-attributes/README.md
+++ b/source-attributes/README.md
@@ -1,0 +1,40 @@
+# NMOS Source Attributes
+
+This Source Attributes parameter register contains values that may be used to identify specific types of content which may be advertised via source resources defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://github.com/AMWA-TV/nmos-discovery-registration).
+
+## Criteria
+
+- Each entry MUST be associated with an existing defined [NMOS Format](../formats)
+- Each entry MUST define a unique attribute name within the scope of a Source.
+- Each entry MUST have a short description.
+- Each entry MUST identify any AMWA Specifications and versions from which it is valid.
+- Each entry MUST link to a schema definition held within this repository.
+- Where linked schemas contain an 'enum' these MAY be expanded over time. Implementations MUST NOT strictly validate against the limited set of permitted values provided in these schemas.
+- Schemas MUST NOT have required attributes removed following their inclusion in this register.
+- Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../README.md#general-procedures-and-criteria).
+
+Query API clients from v1.3 of IS-04 onwards MUST be tolerant to the presence of Source attributes not yet defined here which may be added in later API versions.
+
+## Values
+
+### Relating to urn:x-nmos:format:video
+
+- No parameters currently defined
+
+### Relating to urn:x-nmos:format:audio
+
+- **Name:** channels
+  - **Description:** Identifies labels and symbols for audio channels.
+  - **Specification:** [AMWA IS-04 v1.1](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.1.x)
+  - **Applicability:** AMWA IS-04 v1.1+
+
+### Relating to urn:x-nmos:format:data
+
+- **Name:** event_type
+  - **Description:** Identifies a sub-classification of event data which is being produced, as required for AMWA IS-07
+  - **Specification:** [AMWA IS-04 v1.3](https://github.com/AMWA-TV/nmos-discovery-registration/tree/v1.3-dev)
+  - **Applicability:** AMWA IS-04 v1.3+
+
+### Relating to urn:x-nmos:format:mux
+
+- No parameters currently defined


### PR DESCRIPTION
_Note: This is a first draft. It goes beyond what we currently use the parameter registers for._

This is a first pass at trying to provide a more extensible way to make additions to IS-04 Source/Flow attributes. I'm yet to decide if this is the best way to record this, and schema files are yet to be included.

If this is included, a note should be added to IS-04 before the release of v1.3 to indicate that additional attributes may be added in the future. This may require special handling for Query API key stripping functionality.