### PR TITLE
Fix links

### DIFF
--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -87,13 +87,13 @@ Capabilities are most used by IS-04 Receivers to indicate what they may consume,
 - **Name:** urn:x-nmos:cap:format:colorspace
   - **Description:** Identifies the acceptable colorspace of a video stream.
   - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/README.md) register)
+    - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
     - **Target:** (a) video Flow 'colorspace', (b) SDP attribute 'a=fmtp:' format-specific parameter 'colorimetry'
   - **Applicability:** AMWA IS-04
 - **Name:** urn:x-nmos:cap:format:transfer_characteristic
   - **Description:** Identifies the acceptable transfer characteristic system of a video stream.
   - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/README.md) register)
+    - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
     - **Target:** (a) video Flow 'transfer_characteristic', (b) SDP attribute 'a=fmtp:' format-specific parameter 'TCS'
   - **Applicability:** AMWA IS-04
 - **Name:** urn:x-nmos:cap:format:color_sampling

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -13,9 +13,9 @@ This Flow Attributes parameter register contains extensible attributes and their
 - Each entry MUST link to a schema definition held within this repository (unless covered by a schema within the original specification).
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../common/).
 
-As noted in [IS-04 v1.3](https://specs.amwa.tv/is-04/releases/v1.3/docs/4.3._Behaviour_-_Nodes.html#sources--flows), new Flow attributes may be defined here as opposed to requiring a new version of the specification.
+As noted in [IS-04 v1.3](https://specs.amwa.tv/is-04/v1.3/docs/4.3._Behaviour_-_Nodes.html#sources--flows), new Flow attributes may be defined here as opposed to requiring a new version of the specification.
 
-Query APIs and their clients which support v1.3 of IS-04 or operate in a mixed-version environment MUST be tolerant to the presence of Flow attributes and values which may be added at a later date. This is further detailed in the [IS-04 Upgrade Path](https://specs.amwa.tv/is-04/releases/v1.3/docs/6.0._Upgrade_Path.html) document.
+Query APIs and their clients which support v1.3 of IS-04 or operate in a mixed-version environment MUST be tolerant to the presence of Flow attributes and values which may be added at a later date. This is further detailed in the [IS-04 Upgrade Path](https://specs.amwa.tv/is-04/v1.3/docs/6.0._Upgrade_Path.html) document.
 
 ## Attributes
 

--- a/node-service-types/README.md
+++ b/node-service-types/README.md
@@ -14,7 +14,7 @@ This Node Service Types parameter register contains values that may be used to i
 ## Values
 
 - **Name:** urn:x-manufacturer:service:status
-  - **Description:** Used purely as an example in AMWA IS-04 (see [nodeapi-self-get-200.json](https://specs.amwa.tv/is-04/releases/v1.3/examples/nodeapi-self-get-200.html)).
+  - **Description:** Used purely as an example in AMWA IS-04 (see [nodeapi-self-get-200.json](https://specs.amwa.tv/is-04/v1.3/examples/nodeapi-self-get-200.html)).
   - **Proponent:** [AMWA](https://github.com/AMWA-TV)
 - **Name:** urn:x-ipstudio:service:mdnsbridge/v1.0
   - **Description:** This API provides a zeroconf/HTTP bridge for NMOS service types.


### PR DESCRIPTION
This fixes remaining current broken links in render of nmos-parameter-registers (see also https://github.com/AMWA-TV/nmos-parameter-registers/compare/publish-fix-links which fixed another). A couple of these were introduced by the recent release naming change/

Rendered temporarily at https://specs.amwa.tv/nmos-parameter-registers/branches/publish-fix-links/