### PR TITLE
Add ipmx_pass_through_delay constraint

### DIFF
--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -150,6 +150,13 @@ Capabilities are most used by IS-04 Receivers to indicate what they may consume,
     - **Type:** string (enumerated values as per ST 2110-21, such as '2110TPNL' for narrow linear senders)
     - **Target:** SDP attribute 'a=fmtp:' format-specific parameter 'TP'
     - **Applicability:** AMWA IS-04
+- **Name:** urn:x-nmos:cap:transport:ipmx_pass_through_delay
+  - **Description:** Minimum and maximum delay pass-through delay values in microseconds supported for IPMX receiver.
+  - **Specification:** per [VSF TR-10-1][TR-10-1]
+    - **Type:** JSON object with 'minimum' and 'maximum' number attributes.
+    - **Target:** Used to calculate setting of ST-2110-10:2021 Link Offet Delay via 'ext_link_offset_delay' in AMWA IS-05 Transport Parameter.
+    - **Applicability:** AMWA IS-04
 
 [RFC-4566]: https://tools.ietf.org/html/rfc4566 "SDP: Session Description Protocol"
 [color-sampling]: https://www.iana.org/assignments/media-type-sub-parameters/media-type-sub-parameters.xhtml#media-type-sub-parameters-15 "Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling"
+[TR-10-1]: https://www.vsf.tv/technical_recommendations.shtml "IPMX System Timing and Definitions"

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -151,10 +151,10 @@ Capabilities are most used by IS-04 Receivers to indicate what they may consume,
     - **Target:** SDP attribute 'a=fmtp:' format-specific parameter 'TP'
     - **Applicability:** AMWA IS-04
 - **Name:** urn:x-nmos:cap:transport:ipmx_pass_through_delay
-  - **Description:** Minimum and maximum delay pass-through delay values in microseconds supported for IPMX receiver.
+  - **Description:** Identifies minimum and maximum pass-through delay in microseconds supported by an IPMX receiver.
   - **Specification:** per [VSF TR-10-1][TR-10-1]
-    - **Type:** JSON object with 'minimum' and 'maximum' number attributes.
-    - **Target:** Used to calculate setting of ST-2110-10:2021 Link Offet Delay via 'ext_link_offset_delay' in AMWA IS-05 Transport Parameter.
+    - **Type:** integer
+    - **Note:** Used to calculate setting of ST 2110-10:2021 Link Offset Delay via 'ext_link_offset_delay' in AMWA IS-05 Transport Parameter.
     - **Applicability:** AMWA IS-04
 
 [RFC-4566]: https://tools.ietf.org/html/rfc4566 "SDP: Session Description Protocol"

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -65,6 +65,17 @@
     },
     "urn:x-nmos:cap:transport:st2110_21_sender_type": {
       "$ref": "param_constraint_string.json"
+    },
+    "urn:x-nmos:cap:transport:ipmx_pass_through_delay": {
+      "type": "object",
+      "properties": {
+        "minimum": {
+          "type": "integer"
+        },
+        "maximum": {
+          "type": "integer"
+        }
+      }
     }
   },
   "patternProperties": {

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -67,15 +67,7 @@
       "$ref": "param_constraint_string.json"
     },
     "urn:x-nmos:cap:transport:ipmx_pass_through_delay": {
-      "type": "object",
-      "properties": {
-        "minimum": {
-          "type": "integer"
-        },
-        "maximum": {
-          "type": "integer"
-        }
-      }
+      "$ref": "param_constraint_integer.json"
     }
   },
   "patternProperties": {


### PR DESCRIPTION
Draft VSR TR-10-1 proposes that IPMX receivers report minumum and maximum pass-through delay values supported. This is best done using the parameter constraint set in this PR.

_Note: A further PR will propose a registered value for link offset delay (also covered in vurrent TR-10-1 draft) using `ext_`  syntax. This will be in a new param reg for `ext_` transport params._