### PR TITLE
Make individual register entries linkable

### DIFF
--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -1,6 +1,10 @@
 # NMOS Capabilities
+{:.no_toc}
 
 This Capabilities parameter register contains values that may be used to identify a capability, used in the `caps` property of the resources defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04/).
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -18,147 +22,168 @@ Capabilities are most used by IS-04 Receivers to indicate what they may consume,
 
 ## Values
 
-- **Name:** `media_types`
-  - **Description:** Identifies Flows which may be created or consumed based upon their `media_type` attribute.
-  - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1.x/)
-  - **Applicability:** AMWA IS-04 since v1.1
-- **Name:** `event_types`
-  - **Description:** Identifies Sources or Flows which may be created or consumed based upon their `event_type` attribute.
-  - **Specification:** [AMWA IS-04 v1.3](hhttps://specs.amwa.tv/is-04/v1.3.x/)
-  - **Applicability:** AMWA IS-04 since v1.3
-- **Name:** `constraint_sets`
-  - **Description:** Identifies streams from Senders which may be created or consumed based upon the attributes of the associated Source or Flow or contents of the associated transport file.
-  - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
-  - **Applicability:** AMWA IS-04
-- **Name:** `version`
-  - **Description:** String formatted TAI timestamp (`<seconds>:<nanoseconds>`) indicating when an attribute of the `caps` object last changed.
-  - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
-  - **Applicability:** AMWA IS-04
+### `media_types`
+- **Description:** Identifies Flows which may be created or consumed based upon their `media_type` attribute.
+- **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1.x/)
+- **Applicability:** AMWA IS-04 since v1.1
+
+### `event_types`
+- **Description:** Identifies Sources or Flows which may be created or consumed based upon their `event_type` attribute.
+- **Specification:** [AMWA IS-04 v1.3](hhttps://specs.amwa.tv/is-04/v1.3.x/)
+- **Applicability:** AMWA IS-04 since v1.3
+
+### `constraint_sets`
+- **Description:** Identifies streams from Senders which may be created or consumed based upon the attributes of the associated Source or Flow or contents of the associated transport file.
+- **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
+- **Applicability:** AMWA IS-04
+
+### `version`
+- **Description:** String formatted TAI timestamp (`<seconds>:<nanoseconds>`) indicating when an attribute of the `caps` object last changed.
+- **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
+- **Applicability:** AMWA IS-04
 
 ## Constraint Sets
 
 **Note:** A JSON schema for Constraint Sets, supporting validation of all the Constraint Set Metadata and Parameter Constraints defined in this register, is available as **[constraint_set.json](constraint_set.json)**.
 It MAY be used in place of the file with the same name in the AMWA BCP-004-01 specification.
 
-### Constraint Set Metadata
+## Constraint Set Metadata
 
-- **Name:** `urn:x-nmos:cap:meta:label`
-  - **Description:** Freeform string label to provide a human-readable name for a Constraint Set.
-  - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:meta:preference`
-  - **Description:** Expresses the relative 'weight' that the Receiver assigns to its preference for the streams satisfied by the associated Constraint Set.
-  - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:meta:enabled`
-  - **Description:** Indicates whether a Constraint Set is available to use immediately (true) or whether this is an offline capability which can be activated via some unspecified configuration mechanism (false).
-  - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
-  - **Applicability:** AMWA IS-04
+### `urn:x-nmos:cap:meta:label`
+- **Description:** Freeform string label to provide a human-readable name for a Constraint Set.
+- **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
+- **Applicability:** AMWA IS-04
 
-### Parameter Constraints
+### `urn:x-nmos:cap:meta:preference`
+- **Description:** Expresses the relative 'weight' that the Receiver assigns to its preference for the streams satisfied by the associated Constraint Set.
+- **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
+- **Applicability:** AMWA IS-04
 
-- **Name:** `urn:x-nmos:cap:format:media_type`
-  - **Description:** Identifies streams which may be created or consumed based upon their IANA media type.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** string
-    - **Target:** (a) Flow `media_type` attribute, (b) SDP media description `m=` `<media>` and associated attribute `a=rtpmap:` `<encoding name>`
+### `urn:x-nmos:cap:meta:enabled`
+- **Description:** Indicates whether a Constraint Set is available to use immediately (true) or whether this is an offline capability which can be activated via some unspecified configuration mechanism (false).
+- **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
+- **Applicability:** AMWA IS-04
+
+## Parameter Constraints
+
+### `urn:x-nmos:cap:format:media_type`
+- **Description:** Identifies streams which may be created or consumed based upon their IANA media type.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string
+  - **Target:** (a) Flow `media_type` attribute, (b) SDP media description `m=` `<media>` and associated attribute `a=rtpmap:` `<encoding name>`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:grain_rate`
+- **Description:** Identifies streams which may be created or consumed based upon their grain rate.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** rational
+  - **Target:** (a) Flow `grain_rate` (or from Source if omitted), (b) SDP attribute `a=fmtp:` format-specific parameter `exactframerate`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:frame_width`
+- **Description:** Identifies the acceptable width in pixels of the picture in a video stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** integer
+  - **Target:** (a) video Flow `frame_width`, (b) SDP attribute `a=fmtp:` format-specific parameter `width`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:frame_height`
+- **Description:** Identifies the acceptable height in pixels of the picture in a video stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** integer
+  - **Target:** (a) video Flow `frame_height`, (b) SDP attribute `a=fmtp:` format-specific parameter `height`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:interlace_mode`
+- **Description:** Identifies the acceptable interlace mode of a video stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per AMWA IS-04)
+  - **Target:** (a) video Flow `interlace_mode`, (b) SDP attribute `a=fmtp:` format-specific parameters `interlace` and `segmented`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:colorspace`
+- **Description:** Identifies the acceptable colorspace of a video stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
+  - **Target:** (a) video Flow `colorspace`, (b) SDP attribute `a=fmtp:` format-specific parameter `colorimetry`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:transfer_characteristic`
+- **Description:** Identifies the acceptable transfer characteristic system of a video stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
+  - **Target:** (a) video Flow `transfer_characteristic`, (b) SDP attribute `a=fmtp:` format-specific parameter `TCS`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:color_sampling`
+- **Description:** Identifies the acceptable color (sub-)sampling mode of a video stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per ST 2110-20 and the IANA [Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling][color-sampling])
+  - **Target:** (a) SDP attribute `a=fmtp:` format-specific parameter `sampling`, (b) video Flow `components`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:component_depth`
+- **Description:** Identifies the acceptable number of bits per component sample of a video stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** integer
+  - **Target:** (a) SDP attribute `a=fmtp:` format-specific parameter `depth`, (b) video Flow `components.bit_depth`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:bit_rate`
+- **Description:** Identifies the acceptable bit rate of a compressed video or audio stream, in kilobits/second.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** integer
+  - **Target:** (a) coded video or audio Flow `bit_rate` (defined in the [Flow Attributes](../flow-attributes/) register), (b) depending on the media type, SDP application-specific bandwidth `b=AS:`, for example as per ST 2110-22
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:channel_count`
+- **Description:** Identifies the acceptable number of channels of an audio stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** integer
+  - **Target:** (a) audio Source `channels`, (b) SDP attribute `a=rtpmap:` `<encoding parameters>`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:sample_rate`
+- **Description:** Identifies the acceptable number of samples per second in an audio stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** rational
+  - **Target:** (a) audio Flow `sample_rate`, (b) SDP attribute `a=rtpmap:` `<clock rate>`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:sample_depth`
+- **Description:** Identifies the acceptable number of bits per sample of an audio stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** integer
+  - **Target:** raw audio Flow `bit_depth`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:format:event_type`
+- **Description:** Identifies acceptable data streams based upon their event type.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (values as per AMWA IS-07 [Event types capability management](https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#event-types-capability-management))
+  - **Target:** data Flow `event_type`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:transport:packet_time`
+- **Description:** Identifies the acceptable length of time in milliseconds represented by the media in a packet.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** number (as per [RFC 4566][RFC-4566])
+  - **Target:** SDP attribute `a=ptime:` `<packet time>`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:transport:max_packet_time`
+- **Description:** Identifies the acceptable maximum amount of media that can be encapsulated in each packet, expressed as time in milliseconds.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** number (as per [RFC 4566][RFC-4566])
+  - **Target:** SDP attribute `a=maxptime:` `<maximum packet time>`
+- **Applicability:** AMWA IS-04
+
+### `urn:x-nmos:cap:transport:st2110_21_sender_type`
+- **Description:** Identifies the ST 2110-21 receiver capabilities, expressed as the acceptable sender type or types.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per ST 2110-21, such as `2110TPNL` for narrow linear senders)
+  - **Target:** SDP attribute `a=fmtp:` format-specific parameter `TP`
   - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:grain_rate`
-  - **Description:** Identifies streams which may be created or consumed based upon their grain rate.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** rational
-    - **Target:** (a) Flow `grain_rate` (or from Source if omitted), (b) SDP attribute `a=fmtp:` format-specific parameter `exactframerate`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:frame_width`
-  - **Description:** Identifies the acceptable width in pixels of the picture in a video stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** integer
-    - **Target:** (a) video Flow `frame_width`, (b) SDP attribute `a=fmtp:` format-specific parameter `width`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:frame_height`
-  - **Description:** Identifies the acceptable height in pixels of the picture in a video stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** integer
-    - **Target:** (a) video Flow `frame_height`, (b) SDP attribute `a=fmtp:` format-specific parameter `height`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:interlace_mode`
-  - **Description:** Identifies the acceptable interlace mode of a video stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (enumerated values as per AMWA IS-04)
-    - **Target:** (a) video Flow `interlace_mode`, (b) SDP attribute `a=fmtp:` format-specific parameters `interlace` and `segmented`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:colorspace`
-  - **Description:** Identifies the acceptable colorspace of a video stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
-    - **Target:** (a) video Flow `colorspace`, (b) SDP attribute `a=fmtp:` format-specific parameter `colorimetry`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:transfer_characteristic`
-  - **Description:** Identifies the acceptable transfer characteristic system of a video stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
-    - **Target:** (a) video Flow `transfer_characteristic`, (b) SDP attribute `a=fmtp:` format-specific parameter `TCS`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:color_sampling`
-  - **Description:** Identifies the acceptable color (sub-)sampling mode of a video stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (enumerated values as per ST 2110-20 and the IANA [Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling][color-sampling])
-    - **Target:** (a) SDP attribute `a=fmtp:` format-specific parameter `sampling`, (b) video Flow `components`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:component_depth`
-  - **Description:** Identifies the acceptable number of bits per component sample of a video stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** integer
-    - **Target:** (a) SDP attribute `a=fmtp:` format-specific parameter `depth`, (b) video Flow `components.bit_depth`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:bit_rate`
-  - **Description:** Identifies the acceptable bit rate of a compressed video or audio stream, in kilobits/second.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** integer
-    - **Target:** (a) coded video or audio Flow `bit_rate` (defined in the [Flow Attributes](../flow-attributes/) register), (b) depending on the media type, SDP application-specific bandwidth `b=AS:`, for example as per ST 2110-22
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:channel_count`
-  - **Description:** Identifies the acceptable number of channels of an audio stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** integer
-    - **Target:** (a) audio Source `channels`, (b) SDP attribute `a=rtpmap:` `<encoding parameters>`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:sample_rate`
-  - **Description:** Identifies the acceptable number of samples per second in an audio stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** rational
-    - **Target:** (a) audio Flow `sample_rate`, (b) SDP attribute `a=rtpmap:` `<clock rate>`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:sample_depth`
-  - **Description:** Identifies the acceptable number of bits per sample of an audio stream.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** integer
-    - **Target:** raw audio Flow `bit_depth`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:format:event_type`
-  - **Description:** Identifies acceptable data streams based upon their event type.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (values as per AMWA IS-07 [Event types capability management](https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#event-types-capability-management))
-    - **Target:** data Flow `event_type`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:transport:packet_time`
-  - **Description:** Identifies the acceptable length of time in milliseconds represented by the media in a packet.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** number (as per [RFC 4566][RFC-4566])
-    - **Target:** SDP attribute `a=ptime:` `<packet time>`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:transport:max_packet_time`
-  - **Description:** Identifies the acceptable maximum amount of media that can be encapsulated in each packet, expressed as time in milliseconds.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** number (as per [RFC 4566][RFC-4566])
-    - **Target:** SDP attribute `a=maxptime:` `<maximum packet time>`
-  - **Applicability:** AMWA IS-04
-- **Name:** `urn:x-nmos:cap:transport:st2110_21_sender_type`
-  - **Description:** Identifies the ST 2110-21 receiver capabilities, expressed as the acceptable sender type or types.
-  - **Specification:** per AMWA BCP-004-01
-    - **Type:** string (enumerated values as per ST 2110-21, such as `2110TPNL` for narrow linear senders)
-    - **Target:** SDP attribute `a=fmtp:` format-specific parameter `TP`
-    - **Applicability:** AMWA IS-04
 
 [RFC-4566]: https://tools.ietf.org/html/rfc4566 "SDP: Session Description Protocol"
 [color-sampling]: https://www.iana.org/assignments/media-type-sub-parameters/media-type-sub-parameters.xhtml#media-type-sub-parameters-15 "Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling"

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -18,6 +18,8 @@ Query API clients MUST be tolerant to the presence of capabilities not yet defin
 
 Manufacturers MAY use their own namespaces to indicate capabilities which are not currently defined within the NMOS namespace (`urn:x-nmos:cap:`). In order to avoid collisions with simple names allocated by AMWA specifications, they MUST NOT use capability names that do not start with `urn:`.
 
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.
+
 Capabilities are most used by IS-04 Receivers to indicate what they may consume, but may be used by other `caps` objects in the future, potentially to indicate what they may be re-configured to generate.
 
 ## Values
@@ -48,7 +50,7 @@ Capabilities are most used by IS-04 Receivers to indicate what they may consume,
 
 ## Constraint Set
 
-**Note:** A JSON schema for a Constraint Set, supporting validation of all the Constraint Set Metadata and Parameter Constraints defined in this register, is available as **[constraint_set.json](constraint_set.json)**.
+Note: A JSON schema for a Constraint Set, supporting validation of all the Constraint Set Metadata and Parameter Constraints defined in this register, is available as **[constraint_set.json](constraint_set.json)**.
 It MAY be used in place of the file with the same name in the AMWA BCP-004-01 specification.
 
 ## Constraint Set Metadata

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -22,163 +22,187 @@ Capabilities are most used by IS-04 Receivers to indicate what they may consume,
 
 ## Values
 
-### `media_types`
+### Media Types
+- **Name:** `media_types`
 - **Description:** Identifies Flows which may be created or consumed based upon their `media_type` attribute.
 - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1.x/)
 - **Applicability:** AMWA IS-04 since v1.1
 
-### `event_types`
+### Event Types
+- **Name:** `event_types`
 - **Description:** Identifies Sources or Flows which may be created or consumed based upon their `event_type` attribute.
 - **Specification:** [AMWA IS-04 v1.3](hhttps://specs.amwa.tv/is-04/v1.3.x/)
 - **Applicability:** AMWA IS-04 since v1.3
 
-### `constraint_sets`
+### Constraint Sets
+- **Name:** `constraint_sets`
 - **Description:** Identifies streams from Senders which may be created or consumed based upon the attributes of the associated Source or Flow or contents of the associated transport file.
 - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
 - **Applicability:** AMWA IS-04
 
-### `version`
+### Version
+- **Name:** `version`
 - **Description:** String formatted TAI timestamp (`<seconds>:<nanoseconds>`) indicating when an attribute of the `caps` object last changed.
 - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
 - **Applicability:** AMWA IS-04
 
-## Constraint Sets
+## Constraint Set
 
-**Note:** A JSON schema for Constraint Sets, supporting validation of all the Constraint Set Metadata and Parameter Constraints defined in this register, is available as **[constraint_set.json](constraint_set.json)**.
+**Note:** A JSON schema for a Constraint Set, supporting validation of all the Constraint Set Metadata and Parameter Constraints defined in this register, is available as **[constraint_set.json](constraint_set.json)**.
 It MAY be used in place of the file with the same name in the AMWA BCP-004-01 specification.
 
 ## Constraint Set Metadata
 
-### `urn:x-nmos:cap:meta:label`
+### Label
+- **Name:** `urn:x-nmos:cap:meta:label`
 - **Description:** Freeform string label to provide a human-readable name for a Constraint Set.
 - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:meta:preference`
+### Preference
+- **Name:** `urn:x-nmos:cap:meta:preference`
 - **Description:** Expresses the relative 'weight' that the Receiver assigns to its preference for the streams satisfied by the associated Constraint Set.
 - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:meta:enabled`
+### Enabled
+- **Name:** `urn:x-nmos:cap:meta:enabled`
 - **Description:** Indicates whether a Constraint Set is available to use immediately (true) or whether this is an offline capability which can be activated via some unspecified configuration mechanism (false).
 - **Specification:** [AMWA BCP-004-01](https://specs.amwa.tv/bcp-004-01/v1.0.x/)
 - **Applicability:** AMWA IS-04
 
 ## Parameter Constraints
 
-### `urn:x-nmos:cap:format:media_type`
+### Media Type
+- **Name:** `urn:x-nmos:cap:format:media_type`
 - **Description:** Identifies streams which may be created or consumed based upon their IANA media type.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** string
   - **Target:** (a) Flow `media_type` attribute, (b) SDP media description `m=` `<media>` and associated attribute `a=rtpmap:` `<encoding name>`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:grain_rate`
+### Grain Rate
+- **Name:** `urn:x-nmos:cap:format:grain_rate`
 - **Description:** Identifies streams which may be created or consumed based upon their grain rate.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** rational
   - **Target:** (a) Flow `grain_rate` (or from Source if omitted), (b) SDP attribute `a=fmtp:` format-specific parameter `exactframerate`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:frame_width`
+### Frame Width
+- **Name:** `urn:x-nmos:cap:format:frame_width`
 - **Description:** Identifies the acceptable width in pixels of the picture in a video stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** integer
   - **Target:** (a) video Flow `frame_width`, (b) SDP attribute `a=fmtp:` format-specific parameter `width`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:frame_height`
+### Frame Height
+- **Name:** `urn:x-nmos:cap:format:frame_height`
 - **Description:** Identifies the acceptable height in pixels of the picture in a video stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** integer
   - **Target:** (a) video Flow `frame_height`, (b) SDP attribute `a=fmtp:` format-specific parameter `height`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:interlace_mode`
+### Interlace Mode
+- **Name:** `urn:x-nmos:cap:format:interlace_mode`
 - **Description:** Identifies the acceptable interlace mode of a video stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** string (enumerated values as per AMWA IS-04)
   - **Target:** (a) video Flow `interlace_mode`, (b) SDP attribute `a=fmtp:` format-specific parameters `interlace` and `segmented`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:colorspace`
+### Colorspace
+- **Name:** `urn:x-nmos:cap:format:colorspace`
 - **Description:** Identifies the acceptable colorspace of a video stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
   - **Target:** (a) video Flow `colorspace`, (b) SDP attribute `a=fmtp:` format-specific parameter `colorimetry`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:transfer_characteristic`
+### Transfer Characteristic
+- **Name:** `urn:x-nmos:cap:format:transfer_characteristic`
 - **Description:** Identifies the acceptable transfer characteristic system of a video stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
   - **Target:** (a) video Flow `transfer_characteristic`, (b) SDP attribute `a=fmtp:` format-specific parameter `TCS`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:color_sampling`
+### Color Sampling
+- **Name:** `urn:x-nmos:cap:format:color_sampling`
 - **Description:** Identifies the acceptable color (sub-)sampling mode of a video stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** string (enumerated values as per ST 2110-20 and the IANA [Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling][color-sampling])
   - **Target:** (a) SDP attribute `a=fmtp:` format-specific parameter `sampling`, (b) video Flow `components`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:component_depth`
+### Component Depth
+- **Name:** `urn:x-nmos:cap:format:component_depth`
 - **Description:** Identifies the acceptable number of bits per component sample of a video stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** integer
   - **Target:** (a) SDP attribute `a=fmtp:` format-specific parameter `depth`, (b) video Flow `components.bit_depth`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:bit_rate`
+### Bit Rate
+- **Name:** `urn:x-nmos:cap:format:bit_rate`
 - **Description:** Identifies the acceptable bit rate of a compressed video or audio stream, in kilobits/second.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** integer
   - **Target:** (a) coded video or audio Flow `bit_rate` (defined in the [Flow Attributes](../flow-attributes/) register), (b) depending on the media type, SDP application-specific bandwidth `b=AS:`, for example as per ST 2110-22
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:channel_count`
+### Channel Count
+- **Name:** `urn:x-nmos:cap:format:channel_count`
 - **Description:** Identifies the acceptable number of channels of an audio stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** integer
   - **Target:** (a) audio Source `channels`, (b) SDP attribute `a=rtpmap:` `<encoding parameters>`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:sample_rate`
+### Sample Rate
+- **Name:** `urn:x-nmos:cap:format:sample_rate`
 - **Description:** Identifies the acceptable number of samples per second in an audio stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** rational
   - **Target:** (a) audio Flow `sample_rate`, (b) SDP attribute `a=rtpmap:` `<clock rate>`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:sample_depth`
+### Sample Depth
+- **Name:** `urn:x-nmos:cap:format:sample_depth`
 - **Description:** Identifies the acceptable number of bits per sample of an audio stream.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** integer
   - **Target:** raw audio Flow `bit_depth`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:format:event_type`
+### Event Type
+- **Name:** `urn:x-nmos:cap:format:event_type`
 - **Description:** Identifies acceptable data streams based upon their event type.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** string (values as per AMWA IS-07 [Event types capability management](https://specs.amwa.tv/is-07/releases/v1.0.1/docs/3.0._Event_types.html#event-types-capability-management))
   - **Target:** data Flow `event_type`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:transport:packet_time`
+### Packet Time
+- **Name:** `urn:x-nmos:cap:transport:packet_time`
 - **Description:** Identifies the acceptable length of time in milliseconds represented by the media in a packet.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** number (as per [RFC 4566][RFC-4566])
   - **Target:** SDP attribute `a=ptime:` `<packet time>`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:transport:max_packet_time`
+### Max Packet Time
+- **Name:** `urn:x-nmos:cap:transport:max_packet_time`
 - **Description:** Identifies the acceptable maximum amount of media that can be encapsulated in each packet, expressed as time in milliseconds.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** number (as per [RFC 4566][RFC-4566])
   - **Target:** SDP attribute `a=maxptime:` `<maximum packet time>`
 - **Applicability:** AMWA IS-04
 
-### `urn:x-nmos:cap:transport:st2110_21_sender_type`
+### ST 2110-21 Sender Type
+- **Name:** `urn:x-nmos:cap:transport:st2110_21_sender_type`
 - **Description:** Identifies the ST 2110-21 receiver capabilities, expressed as the acceptable sender type or types.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** string (enumerated values as per ST 2110-21, such as `2110TPNL` for narrow linear senders)

--- a/common/README.md
+++ b/common/README.md
@@ -27,3 +27,5 @@ So, for example, its criteria includes the following statements:
 > - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the General Procedures and Criteria.
 
 However, modifications to a parameter register may be more closely controlled than this. For example, in the case of the [NMOS Formats](../formats/) parameter register, values are defined only by revisions of AMWA IS-04 itself.
+
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.

--- a/device-control-types/README.md
+++ b/device-control-types/README.md
@@ -16,6 +16,8 @@ Note: the `controls` property was introduced in AMWA IS-04 v1.1.
 - In the case of substantial revision to the control specification, a new control type name MUST be defined. Using versioned names is therefore RECOMMENDED.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../common/).
 
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.
+
 ## Values
 
 ### Connection API v1.0

--- a/device-control-types/README.md
+++ b/device-control-types/README.md
@@ -1,7 +1,11 @@
 # NMOS Device Control Types
+{:.no_toc}
 
 This Device Control Types parameter register contains values that may be used to identify a control `type`, used in the `controls` property of the device resource defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04).
 Note: the `controls` property was introduced in AMWA IS-04 v1.1.
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -14,28 +18,32 @@ Note: the `controls` property was introduced in AMWA IS-04 v1.1.
 
 ## Values
 
-- **Name:** `urn:x-nmos:control:sr-ctrl/v1.0`
-  - **Description:** Identifies the Connection API v1.0.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [AMWA IS-05 NMOS Device Connection Management v1.0](https://specs.amwa.tv/is-05/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.2
-- **Name:** `urn:x-nmos:control:sr-ctrl/v1.1`
-  - **Description:** Identifies the Connection API v1.1.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [AMWA IS-05 NMOS Device Connection Management v1.1](https://specs.amwa.tv/is-05/v1.1)
-  - **Applicability:** AMWA IS-04 since v1.3
-- **Name:** `urn:x-nmos:control:events/v1.0`
-  - **Description:** Identifies the Events API v1.0.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [AMWA IS-07 NMOS Event & Tally v1.0](https://specs.amwa.tv/is-07/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.3
-- **Name:** `urn:x-nmos:control:cm-ctrl/v1.0`
-  - **Description:** Identifies the Channel Mapping API v1.0.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [AMWA IS-08 NMOS Audio Channel Mapping v1.0](https://specs.amwa.tv/is-08/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.2
-- **Name:** `urn:x-nmos:control:manifest-base/v1.0`
-  - **Description:** Use of this control type provides redundant locators for sender transport files (also known as manifests).
-  - **Proponent:** [Sony](https://github.com/sony) (contact [@garethsb](https://github.com/garethsb))
-  - **Specification:** [Manifest Base URL](manifest-base.md)
-  - **Applicability:** AMWA IS-04 since v1.1
+### `urn:x-nmos:control:sr-ctrl/v1.0`
+- **Description:** Identifies the Connection API v1.0.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [AMWA IS-05 NMOS Device Connection Management v1.0](https://specs.amwa.tv/is-05/v1.0)
+- **Applicability:** AMWA IS-04 since v1.2
+
+### `urn:x-nmos:control:sr-ctrl/v1.1`
+- **Description:** Identifies the Connection API v1.1.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [AMWA IS-05 NMOS Device Connection Management v1.1](https://specs.amwa.tv/is-05/v1.1)
+- **Applicability:** AMWA IS-04 since v1.3
+
+### `urn:x-nmos:control:events/v1.0`
+- **Description:** Identifies the Events API v1.0.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [AMWA IS-07 NMOS Event & Tally v1.0](https://specs.amwa.tv/is-07/v1.0)
+- **Applicability:** AMWA IS-04 since v1.3
+
+### `urn:x-nmos:control:cm-ctrl/v1.0`
+- **Description:** Identifies the Channel Mapping API v1.0.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [AMWA IS-08 NMOS Audio Channel Mapping v1.0](https://specs.amwa.tv/is-08/v1.0)
+- **Applicability:** AMWA IS-04 since v1.2
+
+### `urn:x-nmos:control:manifest-base/v1.0`
+- **Description:** Use of this control type provides redundant locators for sender transport files (also known as manifests).
+- **Proponent:** [Sony](https://github.com/sony) (contact [@garethsb](https://github.com/garethsb))
+- **Specification:** [Manifest Base URL](manifest-base.md)
+- **Applicability:** AMWA IS-04 since v1.1

--- a/device-control-types/README.md
+++ b/device-control-types/README.md
@@ -18,31 +18,36 @@ Note: the `controls` property was introduced in AMWA IS-04 v1.1.
 
 ## Values
 
-### `urn:x-nmos:control:sr-ctrl/v1.0`
+### Connection API v1.0
+- **Name:** `urn:x-nmos:control:sr-ctrl/v1.0`
 - **Description:** Identifies the Connection API v1.0.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [AMWA IS-05 NMOS Device Connection Management v1.0](https://specs.amwa.tv/is-05/v1.0)
 - **Applicability:** AMWA IS-04 since v1.2
 
-### `urn:x-nmos:control:sr-ctrl/v1.1`
+### Connection API v1.1
+- **Name:** `urn:x-nmos:control:sr-ctrl/v1.1`
 - **Description:** Identifies the Connection API v1.1.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [AMWA IS-05 NMOS Device Connection Management v1.1](https://specs.amwa.tv/is-05/v1.1)
 - **Applicability:** AMWA IS-04 since v1.3
 
-### `urn:x-nmos:control:events/v1.0`
+### Events API v1.0
+- **Name:** `urn:x-nmos:control:events/v1.0`
 - **Description:** Identifies the Events API v1.0.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [AMWA IS-07 NMOS Event & Tally v1.0](https://specs.amwa.tv/is-07/v1.0)
 - **Applicability:** AMWA IS-04 since v1.3
 
-### `urn:x-nmos:control:cm-ctrl/v1.0`
+### Channel Mapping API v1.0
+- **Name:** `urn:x-nmos:control:cm-ctrl/v1.0`
 - **Description:** Identifies the Channel Mapping API v1.0.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [AMWA IS-08 NMOS Audio Channel Mapping v1.0](https://specs.amwa.tv/is-08/v1.0)
 - **Applicability:** AMWA IS-04 since v1.2
 
-### `urn:x-nmos:control:manifest-base/v1.0`
+### Manifest Base v1.0
+- **Name:** `urn:x-nmos:control:manifest-base/v1.0`
 - **Description:** Use of this control type provides redundant locators for sender transport files (also known as manifests).
 - **Proponent:** [Sony](https://github.com/sony) (contact [@garethsb](https://github.com/garethsb))
 - **Specification:** [Manifest Base URL](manifest-base.md)

--- a/device-types/README.md
+++ b/device-types/README.md
@@ -18,13 +18,15 @@ Manufacturers MAY use their own namespaces to indicate device types which are no
 
 ## Values
 
-### `urn:x-nmos:device:generic`
+### Generic Device
+- **Name:** `urn:x-nmos:device:generic`
 - **Description:** Generic device.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.1
 
-### `urn:x-nmos:device:pipeline`
+### Pipeline Device
+- **Name:** `urn:x-nmos:device:pipeline`
 - **Description:** Pipeline device.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)

--- a/device-types/README.md
+++ b/device-types/README.md
@@ -1,6 +1,10 @@
 # NMOS Device Types
+{:.no_toc}
 
 This Device Types parameter register contains values that may be used to identify the role of a device within the production environment (such as camera, mixer, tally light etc.), used in the `type` property of the device resource defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04).
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -14,13 +18,14 @@ Manufacturers MAY use their own namespaces to indicate device types which are no
 
 ## Values
 
-- **Name:** `urn:x-nmos:device:generic`
-  - **Description:** Generic device.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.1
-- **Name:** `urn:x-nmos:device:pipeline`
-  - **Description:** Pipeline device.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.1
+### `urn:x-nmos:device:generic`
+- **Description:** Generic device.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.1
+
+### `urn:x-nmos:device:pipeline`
+- **Description:** Pipeline device.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.1

--- a/device-types/README.md
+++ b/device-types/README.md
@@ -16,6 +16,8 @@ This Device Types parameter register contains values that may be used to identif
 
 Manufacturers MAY use their own namespaces to indicate device types which are not currently defined within the NMOS namespace.
 
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.
+
 ## Values
 
 ### Generic Device

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -23,7 +23,7 @@ Query APIs and their clients which support v1.3 of IS-04 or operate in a mixed-v
 
 ## Attributes
 
-**Note:** JSON schemas supporting validation of all the attributes defined in this register are available as **[flow_video_register.json](flow_video_register.json)** and **[flow_audio_register.json](flow_audio_register.json)**.
+Note: JSON schemas supporting validation of all the attributes defined in this register are available as **[flow_video_register.json](flow_video_register.json)** and **[flow_audio_register.json](flow_audio_register.json)**.
 These MAY be used in addition to the schemas, such as _flow_video.json_ and _flow_audio.json_, found in the AMWA IS-04 specification.
 
 ### Bit Rate

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -1,6 +1,10 @@
 # NMOS Flow Attributes
+{:.no_toc}
 
 This Flow Attributes parameter register contains extensible attributes and their permitted values which may be used in Flow resources within the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04).
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -22,67 +26,71 @@ Query APIs and their clients which support v1.3 of IS-04 or operate in a mixed-v
 **Note:** JSON schemas supporting validation of all the attributes defined in this register are available as **[flow_video_register.json](flow_video_register.json)** and **[flow_audio_register.json](flow_audio_register.json)**.
 These MAY be used in addition to the schemas, such as _flow_video.json_ and _flow_audio.json_, found in the AMWA IS-04 specification.
 
+### Bit Rate
 - **Name:** `bit_rate`
-  - **Description:** Bit rate, in kilobits/second.
-  - **Specification:** Depends on the media type
-  - **Applicability:** `urn:x-nmos:format:video` or `urn:x-nmos:format:audio`
-    -  For `video/jxsv`, the value specifies the average bit rate of an RTP stream as per RFC 9134 including IP headers and payload as per SMPTE ST 2110-22
-  - **Permitted Values:**
-    - Since AMWA IS-04 v1.3
-      - Integer value expressed in units of 1000 bits per second, rounding up.
+- **Description:** Bit rate, in kilobits/second.
+- **Specification:** Depends on the media type
+- **Applicability:** `urn:x-nmos:format:video` or `urn:x-nmos:format:audio`
+  -  For `video/jxsv`, the value specifies the average bit rate of an RTP stream as per RFC 9134 including IP headers and payload as per SMPTE ST 2110-22
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.3
+    - Integer value expressed in units of 1000 bits per second, rounding up.
 
+### Colorspace
 - **Name:** `colorspace`
-  - **Description:** Colorspace used for the video.
-  - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
-  - **Applicability:** `urn:x-nmos:format:video`
-  - **Permitted Values:**
-    - Since AMWA IS-04 v1.1, values complying with the IS-04 schema
-      - `BT601`
-      - `BT709`
-      - `BT2020`
-      - `BT2100`
-    - Since AMWA IS-04 v1.3, values defined for the colorimetry format-specific parameter in any published revision of SMPTE ST 2110-20.
-    - Since ST 2110-20:2017
-      - `ST2065-1`
-      - `ST2065-3`
-      - `UNSPECIFIED` (when no other value applies)
-      - `XYZ`
-    - Since ST 2110-20:2021
-      - `ALPHA`
+- **Description:** Colorspace used for the video.
+- **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
+- **Applicability:** `urn:x-nmos:format:video`
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.1, values complying with the IS-04 schema
+    - `BT601`
+    - `BT709`
+    - `BT2020`
+    - `BT2100`
+  - Since AMWA IS-04 v1.3, values defined for the colorimetry format-specific parameter in any published revision of SMPTE ST 2110-20.
+  - Since ST 2110-20:2017
+    - `ST2065-1`
+    - `ST2065-3`
+    - `UNSPECIFIED` (when no other value applies)
+    - `XYZ`
+  - Since ST 2110-20:2021
+    - `ALPHA`
 
+### Components
 - **Name:** `components`
-  - **Description:** Array of objects describing the components of the video.
-  - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1) for raw video Flows, extended by this entry to coded video Flows since v1.3
-  - **Applicability:** `urn:x-nmos:format:video`
-  - **Permitted Values:**
-    - For raw video Flows, since AMWA IS-04 v1.1, values complying with the IS-04 schema
-    - For coded video Flows, since AMWA IS-04 v1.3, values complying with the schema accompanying this register
-    - For example:  
-      ```json
-      "components": [
-        { "name": "Y",  "width": 1280, "height": 720, "bit_depth": 10 },
-        { "name": "Cb", "width": 640,  "height": 720, "bit_depth": 10 },
-        { "name": "Cr", "width": 640,  "height": 720, "bit_depth": 10 }
-      ]
-      ```
+- **Description:** Array of objects describing the components of the video.
+- **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1) for raw video Flows, extended by this entry to coded video Flows since v1.3
+- **Applicability:** `urn:x-nmos:format:video`
+- **Permitted Values:**
+  - For raw video Flows, since AMWA IS-04 v1.1, values complying with the IS-04 schema
+  - For coded video Flows, since AMWA IS-04 v1.3, values complying with the schema accompanying this register
+  - For example:  
+    ```json
+    "components": [
+      { "name": "Y",  "width": 1280, "height": 720, "bit_depth": 10 },
+      { "name": "Cb", "width": 640,  "height": 720, "bit_depth": 10 },
+      { "name": "Cr", "width": 640,  "height": 720, "bit_depth": 10 }
+    ]
+    ```
 
+### Transfer Characteristic
 - **Name:** `transfer_characteristic`
-  - **Description:** Transfer characteristic.
-  - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
-  - **Applicability:** `urn:x-nmos:format:video`
-  - **Permitted Values:**
-    - Since AMWA IS-04 v1.1, values complying with the IS-04 schema
-      - `SDR`
-      - `HLG`
-      - `PQ`
-    - Since AMWA IS-04 v1.3, values defined for the TCS format-specific parameter in any published revision of SMPTE ST 2110-20.
-    - Since ST 2110-20:2017
-      - `LINEAR`
-      - `BT2100LINPQ`
-      - `BT2100LINHLG`
-      - `ST2065-1`
-      - `ST428-1`
-      - `DENSITY`
-      - `UNSPECIFIED` (when no other value applies)
-    - Since ST 2110-20:2021
-      - `ST2115LOGS3`
+- **Description:** Transfer characteristic.
+- **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
+- **Applicability:** `urn:x-nmos:format:video`
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.1, values complying with the IS-04 schema
+    - `SDR`
+    - `HLG`
+    - `PQ`
+  - Since AMWA IS-04 v1.3, values defined for the TCS format-specific parameter in any published revision of SMPTE ST 2110-20.
+  - Since ST 2110-20:2017
+    - `LINEAR`
+    - `BT2100LINPQ`
+    - `BT2100LINHLG`
+    - `ST2065-1`
+    - `ST428-1`
+    - `DENSITY`
+    - `UNSPECIFIED` (when no other value applies)
+  - Since ST 2110-20:2021
+    - `ST2115LOGS3`

--- a/formats/README.md
+++ b/formats/README.md
@@ -18,27 +18,32 @@ Query API clients MUST be tolerant to the presence of formats not yet defined he
 
 ## Values
 
-### `urn:x-nmos:format:video`
+### Video
+- **Name:** `urn:x-nmos:format:video`
 - **Description:** Identifies (sources of) video flows.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0
 
-### `urn:x-nmos:format:audio`
+### Audio
+- **Name:** `urn:x-nmos:format:audio`
 - **Description:** Identifies (sources of) audio flows.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0
 
-### `urn:x-nmos:format:data`
+### Data
+- **Name:** `urn:x-nmos:format:data`
 - **Description:** Identifies (sources of) data flows.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0
 
-### `urn:x-nmos:format:data.event`
+### Event Data
+- **Name:** `urn:x-nmos:format:data.event`
 - **Description:** Identifies (sources of) Query API subscription event Grains.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0
 
-### `urn:x-nmos:format:mux`
+### Multiplexed
+- **Name:** `urn:x-nmos:format:mux`
 - **Description:** Identifies (sources of) multiplexed flows.
 - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
 - **Applicability:** AMWA IS-04 since v1.1

--- a/formats/README.md
+++ b/formats/README.md
@@ -16,6 +16,8 @@ This Formats parameter register contains values that may be used to identify a d
 
 Query API clients MUST be tolerant to the presence of formats not yet defined here which may be added in later API versions.
 
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.
+
 ## Values
 
 ### Video
@@ -36,11 +38,13 @@ Query API clients MUST be tolerant to the presence of formats not yet defined he
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0
 
-### Event Data
+#### Event Data
 - **Name:** `urn:x-nmos:format:data.event`
 - **Description:** Identifies (sources of) Query API subscription event Grains.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0
+
+Note: This subclassification is only used for Query API subscription event data. IS-07 Event & Tally event sources and flows use the URN base.
 
 ### Multiplexed
 - **Name:** `urn:x-nmos:format:mux`

--- a/formats/README.md
+++ b/formats/README.md
@@ -1,6 +1,10 @@
 # NMOS Formats
+{:.no_toc}
 
 This Formats parameter register contains values that may be used to identify a data format, used in the `format` property of the source and flow resources defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04).
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -14,23 +18,27 @@ Query API clients MUST be tolerant to the presence of formats not yet defined he
 
 ## Values
 
-- **Name:** `urn:x-nmos:format:video`
-  - **Description:** Identifies (sources of) video flows.
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.0
-- **Name:** `urn:x-nmos:format:audio`
-  - **Description:** Identifies (sources of) audio flows.
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.0
-- **Name:** `urn:x-nmos:format:data`
-  - **Description:** Identifies (sources of) data flows.
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.0
-- **Name:** `urn:x-nmos:format:data.event`
-  - **Description:** Identifies (sources of) Query API subscription event Grains.
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.0
-- **Name:** `urn:x-nmos:format:mux`
-  - **Description:** Identifies (sources of) multiplexed flows.
-  - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
-  - **Applicability:** AMWA IS-04 since v1.1
+### `urn:x-nmos:format:video`
+- **Description:** Identifies (sources of) video flows.
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.0
+
+### `urn:x-nmos:format:audio`
+- **Description:** Identifies (sources of) audio flows.
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.0
+
+### `urn:x-nmos:format:data`
+- **Description:** Identifies (sources of) data flows.
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.0
+
+### `urn:x-nmos:format:data.event`
+- **Description:** Identifies (sources of) Query API subscription event Grains.
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.0
+
+### `urn:x-nmos:format:mux`
+- **Description:** Identifies (sources of) multiplexed flows.
+- **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
+- **Applicability:** AMWA IS-04 since v1.1

--- a/node-service-types/README.md
+++ b/node-service-types/README.md
@@ -18,11 +18,13 @@ Note: the `services` property was introduced in AMWA IS-04 v1.1.
 
 ## Values
 
-### `urn:x-manufacturer:service:status`
+### Service Status (Example)
+- **Name:** `urn:x-manufacturer:service:status`
 - **Description:** Used purely as an example in AMWA IS-04 (see [nodeapi-self-get-200.json](https://specs.amwa.tv/is-04/v1.3/examples/nodeapi-self-get-200.html)).
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 
-### `urn:x-ipstudio:service:mdnsbridge/v1.0`
+### mDNS Bridge v1.0
+- **Name:** `urn:x-ipstudio:service:mdnsbridge/v1.0`
 - **Description:** This API provides a zeroconf/HTTP bridge for NMOS service types.
 - **Proponent:** [BBC](https://github.com/bbc) (contact [@simonrankine](https://github.com/simonrankine))
 - **Specification:** [NMOS MDNS Bridge](https://github.com/bbc/nmos-mdns-bridge)

--- a/node-service-types/README.md
+++ b/node-service-types/README.md
@@ -16,6 +16,8 @@ Note: the `services` property was introduced in AMWA IS-04 v1.1.
 - In the case of substantial revision to the service specification, a new service type name MUST be defined. Using versioned names is therefore RECOMMENDED.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../common/).
 
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.
+
 ## Values
 
 ### Service Status (Example)

--- a/node-service-types/README.md
+++ b/node-service-types/README.md
@@ -1,7 +1,11 @@
 # NMOS Node Service Types
+{:.no_toc}
 
 This Node Service Types parameter register contains values that may be used to identify a service `type`, used in the `services` property of the node resource defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04).
 Note: the `services` property was introduced in AMWA IS-04 v1.1.
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -14,11 +18,12 @@ Note: the `services` property was introduced in AMWA IS-04 v1.1.
 
 ## Values
 
-- **Name:** `urn:x-manufacturer:service:status`
-  - **Description:** Used purely as an example in AMWA IS-04 (see [nodeapi-self-get-200.json](https://specs.amwa.tv/is-04/v1.3/examples/nodeapi-self-get-200.html)).
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-- **Name:** `urn:x-ipstudio:service:mdnsbridge/v1.0`
-  - **Description:** This API provides a zeroconf/HTTP bridge for NMOS service types.
-  - **Proponent:** [BBC](https://github.com/bbc) (contact [@simonrankine](https://github.com/simonrankine))
-  - **Specification:** [NMOS MDNS Bridge](https://github.com/bbc/nmos-mdns-bridge)
-  - **Applicability:** AMWA IS-04 since v1.0
+### `urn:x-manufacturer:service:status`
+- **Description:** Used purely as an example in AMWA IS-04 (see [nodeapi-self-get-200.json](https://specs.amwa.tv/is-04/v1.3/examples/nodeapi-self-get-200.html)).
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+
+### `urn:x-ipstudio:service:mdnsbridge/v1.0`
+- **Description:** This API provides a zeroconf/HTTP bridge for NMOS service types.
+- **Proponent:** [BBC](https://github.com/bbc) (contact [@simonrankine](https://github.com/simonrankine))
+- **Specification:** [NMOS MDNS Bridge](https://github.com/bbc/nmos-mdns-bridge)
+- **Applicability:** AMWA IS-04 since v1.0

--- a/tags/README.md
+++ b/tags/README.md
@@ -1,8 +1,12 @@
 # NMOS Tags
+{:.no_toc}
 
 This Tags parameter register defines specific and reserved NMOS "tags" for NMOS resources. Tags are part of all common NMOS resources. They enable NMOS resources to expose supplemental information without changing current IS-04 specification while maintaining backward compatibility.
 
 The register contains values that may be used in the `tags` property defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04) since v1.0.
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -13,13 +17,14 @@ The register contains values that may be used in the `tags` property defined in 
 
 ## Values
 
-- **Name:** `urn:x-nmos:tag:grouphint/v1.0`
-  - **Description:** Group tag that can be used in a JSON description for an NMOS resource v1.0.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [Group Hint tags](grouphint.md)
-  - **Applicability:** AMWA IS-04 since v1.0
-- **Name:** `urn:x-nmos:tag:certprov`
-  - **Description:** Certificate Provisioning tag that can be used to advertise if BCP-003-03 is enabled.
-  - **Proponent:** [AMWA](https://www.amwa.tv/)
-  - **Specification:** [Certificate Provisioning tags](certprov.md)
-  - **Applicability:** AMWA IS-04 since v1.0
+### `urn:x-nmos:tag:grouphint/v1.0`
+- **Description:** Group tag that can be used in a JSON description for an NMOS resource v1.0.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [Group Hint tags](grouphint.md)
+- **Applicability:** AMWA IS-04 since v1.0
+
+### `urn:x-nmos:tag:certprov`
+- **Description:** Certificate Provisioning tag that can be used to advertise if BCP-003-03 is enabled.
+- **Proponent:** [AMWA](https://www.amwa.tv/)
+- **Specification:** [Certificate Provisioning tags](certprov.md)
+- **Applicability:** AMWA IS-04 since v1.0

--- a/tags/README.md
+++ b/tags/README.md
@@ -15,6 +15,8 @@ The register contains values that may be used in the `tags` property defined in 
 - In the case of substantial revision to the tag specification, a new tag type name MUST be defined. Using versioned names is therefore RECOMMENDED when this applies.
 - Additions and updates to this parameter register are to be submitted via a Pull Request (PR) according to the [General Procedures and Criteria](../common/).
 
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.
+
 ## Values
 
 ### Group Hint v1.0

--- a/tags/README.md
+++ b/tags/README.md
@@ -17,13 +17,15 @@ The register contains values that may be used in the `tags` property defined in 
 
 ## Values
 
-### `urn:x-nmos:tag:grouphint/v1.0`
+### Group Hint v1.0
+- **Name:** `urn:x-nmos:tag:grouphint/v1.0`
 - **Description:** Group tag that can be used in a JSON description for an NMOS resource v1.0.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [Group Hint tags](grouphint.md)
 - **Applicability:** AMWA IS-04 since v1.0
 
-### `urn:x-nmos:tag:certprov`
+### Certificate Provisioning
+- **Name:** `urn:x-nmos:tag:certprov`
 - **Description:** Certificate Provisioning tag that can be used to advertise if BCP-003-03 is enabled.
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [Certificate Provisioning tags](certprov.md)

--- a/tags/certprov.md
+++ b/tags/certprov.md
@@ -28,7 +28,6 @@ Where
 | --------- | ----------- | ------ |
 | enabled version | A string that defines what version of BCP-003-03 is enabled | Version strings, `v<MAJOR>.<MINOR>`, e.g. `v1.0` |
 
-
 ### Examples
 
 #### 1. BCP-003-03 version 1.0 enabled

--- a/transport-parameters/README.md
+++ b/transport-parameters/README.md
@@ -22,17 +22,20 @@ Instead, they are clearly identified using the prefix `ext_`.
 and **[receiver_transport_params_ext_register.json](receiver_transport_params_ext_register.json)**.
 These MAY be used in addition to the transport-specific schemas, such as **sender_transport_params_rtp.json**, found in the AMWA IS-05 specification.
 
-### `ext_is_07_source_id`
+### IS-07 Source ID
+- **Name:** `ext_is_07_source_id`
 - **Description:** Identifies the Source that emits an IS-07 event.
 - **Specification:** [AMWA IS-07 v1.0](https://specs.amwa.tv/is-07/v1.0)
 - **Applicability:** AMWA IS-05 since v1.1, IS-07 since v1.0
 
-### `ext_is_07_rest_api_url`
+### IS-07 REST API URL
+- **Name:** `ext_is_07_rest_api_url`
 - **Description:** URL of the Events API resource providing the current state and type of an Event emitter (Source).
 - **Specification:** [AMWA IS-07 v1.0](https://specs.amwa.tv/is-07/v1.0)
 - **Applicability:** AMWA IS-05 since v1.1, IS-07 since v1.0
 
-### `ext_link_offset_delay`
+### Link Offset Delay
+- **Name:** `ext_link_offset_delay`
 - **Description:** Identifies the Link Offset Delay used to synchronise Playout Time of all components of a stream by receivers.
 - **Specification:** ST 2110-10:2021 and VSF TR-10-x
 - **Applicability:** AMWA IS-05 since v1.1

--- a/transport-parameters/README.md
+++ b/transport-parameters/README.md
@@ -1,9 +1,13 @@
 # NMOS Transport Parameters
+{:.no_toc}
 
 This register contains the names of additional transport parameters that could be included in the objects in an [IS-05](https://specs.amwa.tv/is-05) `transport_params` array.
 
 For historical reasons, these ["externally-defined" parameters](https://specs.amwa.tv/is-05/v1.1/docs/4.0._Behaviour.html#externally-defined-parameters) are not URNs, like many other registered parameters.
 Instead, they are clearly identified using the prefix `ext_`.
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -18,15 +22,17 @@ Instead, they are clearly identified using the prefix `ext_`.
 and **[receiver_transport_params_ext_register.json](receiver_transport_params_ext_register.json)**.
 These MAY be used in addition to the transport-specific schemas, such as **sender_transport_params_rtp.json**, found in the AMWA IS-05 specification.
 
-- **Name:** `ext_is_07_source_id`
-  - **Description:** Identifies the Source that emits an IS-07 event.
-  - **Specification:** [AMWA IS-07 v1.0](https://specs.amwa.tv/is-07/v1.0)
-  - **Applicability:** AMWA IS-05 since v1.1, IS-07 since v1.0
-- **Name:** `ext_is_07_rest_api_url`
-  - **Description:** URL of the Events API resource providing the current state and type of an Event emitter (Source).
-  - **Specification:** [AMWA IS-07 v1.0](https://specs.amwa.tv/is-07/v1.0)
-  - **Applicability:** AMWA IS-05 since v1.1, IS-07 since v1.0
-- **Name:** `ext_link_offset_delay`
-  - **Description:** Identifies the Link Offset Delay used to synchronise Playout Time of all components of a stream by receivers.
-  - **Specification:** ST 2110-10:2021 and VSF TR-10-x
-  - **Applicability:** AMWA IS-05 since v1.1
+### `ext_is_07_source_id`
+- **Description:** Identifies the Source that emits an IS-07 event.
+- **Specification:** [AMWA IS-07 v1.0](https://specs.amwa.tv/is-07/v1.0)
+- **Applicability:** AMWA IS-05 since v1.1, IS-07 since v1.0
+
+### `ext_is_07_rest_api_url`
+- **Description:** URL of the Events API resource providing the current state and type of an Event emitter (Source).
+- **Specification:** [AMWA IS-07 v1.0](https://specs.amwa.tv/is-07/v1.0)
+- **Applicability:** AMWA IS-05 since v1.1, IS-07 since v1.0
+
+### `ext_link_offset_delay`
+- **Description:** Identifies the Link Offset Delay used to synchronise Playout Time of all components of a stream by receivers.
+- **Specification:** ST 2110-10:2021 and VSF TR-10-x
+- **Applicability:** AMWA IS-05 since v1.1

--- a/transport-parameters/README.md
+++ b/transport-parameters/README.md
@@ -18,7 +18,7 @@ Instead, they are clearly identified using the prefix `ext_`.
 
 ## Values
 
-**Note:** JSON schemas supporting validation of all the `ext_` transport parameters defined in this register are available as **[sender_transport_params_ext_register.json](sender_transport_params_ext_register.json)**
+Note: JSON schemas supporting validation of all the `ext_` transport parameters defined in this register are available as **[sender_transport_params_ext_register.json](sender_transport_params_ext_register.json)**
 and **[receiver_transport_params_ext_register.json](receiver_transport_params_ext_register.json)**.
 These MAY be used in addition to the transport-specific schemas, such as **sender_transport_params_rtp.json**, found in the AMWA IS-05 specification.
 

--- a/transports/README.md
+++ b/transports/README.md
@@ -1,6 +1,10 @@
 # NMOS Transports
+{:.no_toc}
 
 This Transports parameter register contains values that may be used to identify a transport protocol, used in the `transport` property of the sender and receiver resources defined in the [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04).
+
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Criteria
 
@@ -14,29 +18,34 @@ Manufacturers MAY use their own namespaces to indicate transports which are not 
 
 ## Values
 
-- **Name:** `urn:x-nmos:transport:rtp`
-  - **Description:** Identifies the Real-time Transport Protocol.
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
-- **Name:** `urn:x-nmos:transport:rtp.mcast`
-  - **Description:** Identifies RTP multicast.
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
-- **Name:** `urn:x-nmos:transport:rtp.ucast`
-  - **Description:** Identifies RTP unicast.
-  - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
-  - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
-- **Name:** `urn:x-nmos:transport:dash`
-  - **Description:** Identifies the Dynamic Adaptive Streaming over HTTP technology.
-  - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
-  - **Applicability:** AMWA IS-04 since v1.1, IS-05 since v1.0
-- **Name:** `urn:x-nmos:transport:mqtt`
-  - **Description:** Identifies Message Queuing Telemetry Transport (MQTT).
-  - **Specification:** [AMWA IS-05 v1.1](https://specs.amwa.tv/is-05/v1.1)
-  - **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.1, IS-07 since v1.0
-- **Name:** `urn:x-nmos:transport:websocket`
-  - **Description:** Identifies the WebSocket transport type.
-  - **Specification:** [AMWA IS-05 v1.1](https://specs.amwa.tv/is-05/v1.1)
-  - **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.1, IS-07 since v1.0
+### `urn:x-nmos:transport:rtp`
+- **Description:** Identifies the Real-time Transport Protocol.
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
+
+### `urn:x-nmos:transport:rtp.mcast`
+- **Description:** Identifies RTP multicast.
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
+
+### `urn:x-nmos:transport:rtp.ucast`
+- **Description:** Identifies RTP unicast.
+- **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
+- **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
+
+### `urn:x-nmos:transport:dash`
+- **Description:** Identifies the Dynamic Adaptive Streaming over HTTP technology.
+- **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
+- **Applicability:** AMWA IS-04 since v1.1, IS-05 since v1.0
+
+### `urn:x-nmos:transport:mqtt`
+- **Description:** Identifies Message Queuing Telemetry Transport (MQTT).
+- **Specification:** [AMWA IS-05 v1.1](https://specs.amwa.tv/is-05/v1.1)
+- **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.1, IS-07 since v1.0
+
+### `urn:x-nmos:transport:websocket`
+- **Description:** Identifies the WebSocket transport type.
+- **Specification:** [AMWA IS-05 v1.1](https://specs.amwa.tv/is-05/v1.1)
+- **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.1, IS-07 since v1.0
 
 Note: An RTP Transmitter sending to a multicast group should use the transport `urn:x-nmos:transport:rtp.mcast`, but a receiver supporting both unicast and multicast should present the transport `urn:x-nmos:transport:rtp` to indicate its less restrictive state.

--- a/transports/README.md
+++ b/transports/README.md
@@ -16,6 +16,8 @@ This Transports parameter register contains values that may be used to identify 
 
 Manufacturers MAY use their own namespaces to indicate transports which are not currently defined within the NMOS namespace.
 
+Note: AMWA IS-04 specifies general requirements for the construction and [use of URNs](https://specs.amwa.tv/is-04/releases/v1.3.1/docs/2.1._APIs_-_Common_Keys.html#use-of-urns) in NMOS specifications.
+
 ## Values
 
 ### RTP
@@ -26,17 +28,21 @@ Manufacturers MAY use their own namespaces to indicate transports which are not 
 
 Note: An RTP Transmitter sending to a multicast group should use the transport `urn:x-nmos:transport:rtp.mcast`, but a receiver supporting both unicast and multicast should present the transport `urn:x-nmos:transport:rtp` to indicate its less restrictive state.
 
-### RTP Multicast
+#### RTP Multicast
 - **Name:** `urn:x-nmos:transport:rtp.mcast`
 - **Description:** Identifies RTP multicast.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
 
-### RTP Unicast
+Note: The IS-05 v1.1 `/transporttype` endpoint returns the URN base; the subclassification is removed. 
+
+#### RTP Unicast
 - **Name:** `urn:x-nmos:transport:rtp.ucast`
 - **Description:** Identifies RTP unicast.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
+
+Note: The IS-05 v1.1 `/transporttype` endpoint returns the URN base; the subclassification is removed. 
 
 ### DASH
 - **Name:** `urn:x-nmos:transport:dash`

--- a/transports/README.md
+++ b/transports/README.md
@@ -18,34 +18,40 @@ Manufacturers MAY use their own namespaces to indicate transports which are not 
 
 ## Values
 
-### `urn:x-nmos:transport:rtp`
+### RTP
+- **Name:** `urn:x-nmos:transport:rtp`
 - **Description:** Identifies the Real-time Transport Protocol.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
 
-### `urn:x-nmos:transport:rtp.mcast`
+Note: An RTP Transmitter sending to a multicast group should use the transport `urn:x-nmos:transport:rtp.mcast`, but a receiver supporting both unicast and multicast should present the transport `urn:x-nmos:transport:rtp` to indicate its less restrictive state.
+
+### RTP Multicast
+- **Name:** `urn:x-nmos:transport:rtp.mcast`
 - **Description:** Identifies RTP multicast.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
 
-### `urn:x-nmos:transport:rtp.ucast`
+### RTP Unicast
+- **Name:** `urn:x-nmos:transport:rtp.ucast`
 - **Description:** Identifies RTP unicast.
 - **Specification:** [AMWA IS-04 v1.0](https://specs.amwa.tv/is-04/v1.0)
 - **Applicability:** AMWA IS-04 since v1.0, IS-05 since v1.0
 
-### `urn:x-nmos:transport:dash`
+### DASH
+- **Name:** `urn:x-nmos:transport:dash`
 - **Description:** Identifies the Dynamic Adaptive Streaming over HTTP technology.
 - **Specification:** [AMWA IS-04 v1.1](https://specs.amwa.tv/is-04/v1.1)
 - **Applicability:** AMWA IS-04 since v1.1, IS-05 since v1.0
 
-### `urn:x-nmos:transport:mqtt`
+### MQTT
+- **Name:** `urn:x-nmos:transport:mqtt`
 - **Description:** Identifies Message Queuing Telemetry Transport (MQTT).
 - **Specification:** [AMWA IS-05 v1.1](https://specs.amwa.tv/is-05/v1.1)
 - **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.1, IS-07 since v1.0
 
-### `urn:x-nmos:transport:websocket`
+### WebSocket
+- **Name:** `urn:x-nmos:transport:websocket`
 - **Description:** Identifies the WebSocket transport type.
 - **Specification:** [AMWA IS-05 v1.1](https://specs.amwa.tv/is-05/v1.1)
 - **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.1, IS-07 since v1.0
-
-Note: An RTP Transmitter sending to a multicast group should use the transport `urn:x-nmos:transport:rtp.mcast`, but a receiver supporting both unicast and multicast should present the transport `urn:x-nmos:transport:rtp` to indicate its less restrictive state.


### PR DESCRIPTION
Make each individual entry in the registers a heading, to facilitate linking from external documents and automatic generation of a ToC in each register.

I've made separate commits in the PR branch to make the thought process clear, but let's squash-merge this if accepted.