### PR TITLE
Proposed changes for BCP-006

### DIFF
--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -164,6 +164,14 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
     However, note that an `b=AS:` value can include transport protocol overheads, e.g. as per ST 2110-22, not included here
 - **Applicability:** AMWA IS-04
 
+### Profile
+- **Name:** `profile`
+- **Description:** Identifies the acceptable profiles, as defined for the specific media type.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (values depending on the media type)
+  - **Target:** (a) video Flow `profile` (defined in the [Flow Attributes](../flow-attributes/#profile) register), (b) depending on the media type, an SDP attribute `a=fmtp:` format-specific parameter, e.g. `profile`
+- **Applicability:** AMWA IS-04
+
 ### Channel Count
 - **Name:** `urn:x-nmos:cap:format:channel_count`
 - **Description:** Identifies the acceptable number of channels of an audio stream.

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -119,7 +119,7 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
 - **Name:** `urn:x-nmos:cap:format:colorspace`
 - **Description:** Identifies the acceptable colorspace of a video stream.
 - **Specification:** per AMWA BCP-004-01
-  - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
+  - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/#colorspace) register)
   - **Target:** (a) video Flow `colorspace`, (b) SDP attribute `a=fmtp:` format-specific parameter `colorimetry`
 - **Applicability:** AMWA IS-04
 
@@ -127,7 +127,7 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
 - **Name:** `urn:x-nmos:cap:format:transfer_characteristic`
 - **Description:** Identifies the acceptable transfer characteristic system of a video stream.
 - **Specification:** per AMWA BCP-004-01
-  - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/) register)
+  - **Type:** string (enumerated values as per AMWA IS-04 and the [Flow Attributes](../flow-attributes/#transfer-characteristic) register)
   - **Target:** (a) video Flow `transfer_characteristic`, (b) SDP attribute `a=fmtp:` format-specific parameter `TCS`
 - **Applicability:** AMWA IS-04
 
@@ -147,12 +147,21 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
   - **Target:** (a) SDP attribute `a=fmtp:` format-specific parameter `depth`, (b) video Flow `components.bit_depth`
 - **Applicability:** AMWA IS-04
 
+### Bits Per Pixel
+- **Name:** `bits_per_pixel`
+- **Description:** Identifies the range of acceptable compression ratios expressed as bits per pixel (BPP).
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** number
+  - **Target:** (a) coded video Flow `bits_per_pixel` (defined in the [Flow Attributes](../flow-attributes/#bits-per-pixel) register)
+- **Applicability:** AMWA IS-04
+
 ### Bit Rate
 - **Name:** `urn:x-nmos:cap:format:bit_rate`
 - **Description:** Identifies the acceptable bit rate of a compressed video or audio stream, in kilobits/second.
 - **Specification:** per AMWA BCP-004-01
   - **Type:** integer
-  - **Target:** (a) coded video or audio Flow `bit_rate` (defined in the [Flow Attributes](../flow-attributes/) register), (b) depending on the media type, SDP application-specific bandwidth `b=AS:`, for example as per ST 2110-22
+  - **Target:** (a) coded video or audio Flow `bit_rate` (defined in the [Flow Attributes](../flow-attributes/#bit-rate) register), (b) depending on the media type, SDP application-specific bandwidth `b=AS:`  
+    However, note that an `b=AS:` value can include transport protocol overheads, e.g. as per ST 2110-22, not included here
 - **Applicability:** AMWA IS-04
 
 ### Channel Count

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -172,6 +172,14 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
   - **Target:** (a) video Flow `profile` (defined in the [Flow Attributes](../flow-attributes/#profile) register), (b) depending on the media type, an SDP attribute `a=fmtp:` format-specific parameter, e.g. `profile`
 - **Applicability:** AMWA IS-04
 
+### Level
+- **Name:** `level`
+- **Description:** Identifies the acceptable levels, as defined for the specific media type.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (values depending on the media type)
+  - **Target:** (a) video Flow `level` (defined in the [Flow Attributes](../flow-attributes/#level) register), (b) depending on the media type, an SDP attribute `a=fmtp:` format-specific parameter, e.g. `level`
+- **Applicability:** AMWA IS-04
+
 ### Channel Count
 - **Name:** `urn:x-nmos:cap:format:channel_count`
 - **Description:** Identifies the acceptable number of channels of an audio stream.

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -54,6 +54,9 @@
     "urn:x-nmos:cap:format:profile": {
       "$ref": "param_constraint_string.json"
     },
+    "urn:x-nmos:cap:format:level": {
+      "$ref": "param_constraint_string.json"
+    },
     "urn:x-nmos:cap:format:channel_count": {
       "$ref": "param_constraint_integer.json"
     },

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -51,6 +51,9 @@
     "urn:x-nmos:cap:format:bit_rate": {
       "$ref": "param_constraint_integer.json"
     },
+    "urn:x-nmos:cap:format:profile": {
+      "$ref": "param_constraint_string.json"
+    },
     "urn:x-nmos:cap:format:channel_count": {
       "$ref": "param_constraint_integer.json"
     },

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -45,6 +45,9 @@
     "urn:x-nmos:cap:format:component_depth": {
       "$ref": "param_constraint_integer.json"
     },
+    "urn:x-nmos:cap:format:bits_per_pixel": {
+      "$ref": "param_constraint_number.json"
+    },
     "urn:x-nmos:cap:format:bit_rate": {
       "$ref": "param_constraint_integer.json"
     },

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -26,15 +26,22 @@ Query APIs and their clients which support v1.3 of IS-04 or operate in a mixed-v
 Note: JSON schemas supporting validation of all the attributes defined in this register are available as **[flow_video_register.json](flow_video_register.json)** and **[flow_audio_register.json](flow_audio_register.json)**.
 These MAY be used in addition to the schemas, such as _flow_video.json_ and _flow_audio.json_, found in the AMWA IS-04 specification.
 
+### Bits Per Pixel
+- **Name:** `bits_per_pixel`
+- **Description:** Compression ratio expressed as bits per pixel (BPP).
+- **Specification:** Depends on the media type
+- **Applicability:** `urn:x-nmos:format:video`
+- **Permitted Values:**
+  - Floating point numbers
+
 ### Bit Rate
 - **Name:** `bit_rate`
 - **Description:** Bit rate, in kilobits/second.
 - **Specification:** Depends on the media type
 - **Applicability:** `urn:x-nmos:format:video` or `urn:x-nmos:format:audio`
-  -  For `video/jxsv`, the value specifies the average bit rate of an RTP stream as per RFC 9134 including IP headers and payload as per SMPTE ST 2110-22
 - **Permitted Values:**
-  - Since AMWA IS-04 v1.3
-    - Integer value expressed in units of 1000 bits per second, rounding up.
+  - Integer values expressed in units of 1000 bits per second, rounding up
+  - Note that an SDP `b=AS:` application-specific bandwidth value can include transport protocol overheads, e.g. as per ST 2110-22, not included here
 
 ### Colorspace
 - **Name:** `colorspace`
@@ -47,7 +54,7 @@ These MAY be used in addition to the schemas, such as _flow_video.json_ and _flo
     - `BT709`
     - `BT2020`
     - `BT2100`
-  - Since AMWA IS-04 v1.3, values defined for the colorimetry format-specific parameter in any published revision of SMPTE ST 2110-20.
+  - Since AMWA IS-04 v1.3, values defined for the colorimetry format-specific parameter in any published revision of SMPTE ST 2110-20
   - Since ST 2110-20:2017
     - `ST2065-1`
     - `ST2065-3`
@@ -83,7 +90,7 @@ These MAY be used in addition to the schemas, such as _flow_video.json_ and _flo
     - `SDR`
     - `HLG`
     - `PQ`
-  - Since AMWA IS-04 v1.3, values defined for the TCS format-specific parameter in any published revision of SMPTE ST 2110-20.
+  - Since AMWA IS-04 v1.3, values defined for the TCS format-specific parameter in any published revision of SMPTE ST 2110-20
   - Since ST 2110-20:2017
     - `LINEAR`
     - `BT2100LINPQ`

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -80,6 +80,17 @@ These MAY be used in addition to the schemas, such as _flow_video.json_ and _flo
     ]
     ```
 
+### Profile
+- **Name:** `profile`
+- **Description:** Indicates the subset of coding tools that are in use, as defined for the Flow media type.
+- **Specification:** Depends on the media type
+- **Applicability:** `urn:x-nmos:format:video`
+- **Permitted Values:**
+  - String values defined for the Flow media type, as enumerated in the schema accompanying this register
+  - For `video/jxsv`, the values are the profile names defined by ISO/IEC 21122-2, with any white space Unicode characters omitted as per [RFC 9134][RFC-9134]
+  - For example
+    - `Main444.12`
+
 ### Transfer Characteristic
 - **Name:** `transfer_characteristic`
 - **Description:** Transfer characteristic.
@@ -101,3 +112,5 @@ These MAY be used in addition to the schemas, such as _flow_video.json_ and _flo
     - `UNSPECIFIED` (when no other value applies)
   - Since ST 2110-20:2021
     - `ST2115LOGS3`
+
+[RFC-9134]: https://tools.ietf.org/html/rfc9134 "RTP Payload Format for ISO/IEC 21122 (JPEG XS)"

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -80,6 +80,14 @@ These MAY be used in addition to the schemas, such as _flow_video.json_ and _flo
     ]
     ```
 
+### Level
+- **Name:** `level`
+- **Description:** Indicates constraints on parameters of the coding tools that are in use, as defined for the Flow media type.
+- **Specification:** Depends on the media type
+- **Applicability:** `urn:x-nmos:format:video`
+- **Permitted Values:**
+  - String values defined for the Flow media type, as enumerated in the schema accompanying this register
+
 ### Profile
 - **Name:** `profile`
 - **Description:** Indicates the subset of coding tools that are in use, as defined for the Flow media type.

--- a/flow-attributes/flow_video_register.json
+++ b/flow-attributes/flow_video_register.json
@@ -80,6 +80,25 @@
         }
       }
     },
+    "profile": {
+      "description": "Profile. Indicates the subset of coding tools that are in use, as defined for the Flow media type.",
+      "type": "string",
+      "enum": [
+        "HighBayer",
+        "MainBayer",
+        "LightBayer",
+        "High4444.12",
+        "Main4444.12",
+        "High444.12",
+        "Main444.12",
+        "Light444.12",
+        "Main422.10",
+        "Light422.10",
+        "Light-Subline422.10",
+        "MLS.12",
+        "Main420.12"
+      ]
+    },
     "transfer_characteristic": {
       "description": "Transfer characteristic. Values defined for the TCS format-specific parameter in any published revision of SMPTE ST 2110-20.",
       "type": "string",

--- a/flow-attributes/flow_video_register.json
+++ b/flow-attributes/flow_video_register.json
@@ -80,6 +80,10 @@
         }
       }
     },
+    "level": {
+      "description": "Level. Indicates constraints on parameters of the coding tools that are in use, as defined for the Flow media type.",
+      "type": "string"
+    },
     "profile": {
       "description": "Profile. Indicates the subset of coding tools that are in use, as defined for the Flow media type.",
       "type": "string",

--- a/flow-attributes/flow_video_register.json
+++ b/flow-attributes/flow_video_register.json
@@ -4,6 +4,10 @@
   "description": "Describes Video Flow additional and extensible attributes defined in the NMOS Parameter Registers.",
   "title": "Video Flow resource",
   "properties": {
+    "bits_per_pixel": {
+      "description": "Compression ratio expressed as bits per pixel (BPP).",
+      "type": "number"
+    },
     "bit_rate": {
       "description": "Bit rate, in kilobits/second. Integer value expressed in units of 1000 bits per second, rounding up.",
       "type": "integer"


### PR DESCRIPTION
This PR proposes:
* addition of Flow `bits_per_pixel` as an alternative expression of compression ratio vs. `bit_rate`, and matching Receiver parameter constraint
* clarification that Flow `bit_rate` is not expected to be identical to SDP `b=AS:` value per ST 2110-22
* addition of Flow `profile` and matching Receiver parameter constraint
* addition of Flow `level` and matching Receiver parameter constraint

Rationale for adding Bits Per Pixel:

* ST 2110-22 SDP b=AS: bit rate includes packetization overhead; not a good Flow param
* For intra-frame only codecs, bit rate and frame rate constraints don’t work well together
* JPEG XS compression is naturally expressed as bits per pixel (and RFC 9134 doesn’t require SDP `b=AS:` bit rate)

The `bits_per_pixel` and `profile` entries will be referenced by a PR to update work-in-progress BCP-006-01 shortly, while `profile` and `level` are likely to be used for future BCP-066-xx for NMOS with H.264 and H.265.