### PR TITLE
Add description of tags for VSF TR-09-2 on behalf of VSF ST 2110 over WAN group

### DIFF
--- a/tags/README.md
+++ b/tags/README.md
@@ -32,3 +32,17 @@ Note: AMWA IS-04 specifies general requirements for the construction and [use of
 - **Proponent:** [AMWA](https://www.amwa.tv/)
 - **Specification:** [Certificate Provisioning tags](certprov.md)
 - **Applicability:** AMWA IS-04 since v1.0
+
+### TR-09-2 Booking List
+- **Name:** `urn:x-vsf:tag:tr-09-2:booking-list/v1.0`
+- **Description:** Booking List tag that can be used to indicate that an NMOS resource is part of one or more TR-09-2 bookings.
+- **Proponent:** [VSF](https://www.vsf.tv/)
+- **Specification:** [TR-09-2 tags](tr-09-2.md)
+- **Applicability:** AMWA IS-04 since v1.0
+
+### TR-09-2 Current Booking
+- **Name:** `urn:x-vsf:tag:tr-09-2:current-booking/v1.0`
+- **Description:** Current Booking tag that can be used to indicate that an NMOS resource is part of an active TR-09-2 booking.
+- **Proponent:** [VSF](https://www.vsf.tv/)
+- **Specification:** [TR-09-2 tags](tr-09-2.md)
+- **Applicability:** AMWA IS-04 since v1.0

--- a/tags/README.md
+++ b/tags/README.md
@@ -42,7 +42,7 @@ Note: AMWA IS-04 specifies general requirements for the construction and [use of
 
 ### TR-09-2 Current Booking
 - **Name:** `urn:x-vsf:tag:tr-09-2:current-booking/v1.0`
-- **Description:** Current Booking tag that can be used to indicate that an NMOS resource is part of an active TR-09-2 booking.
+- **Description:** Current Booking tag that can be used to indicate the current active TR-09-2 booking.
 - **Proponent:** [VSF](https://www.vsf.tv/)
 - **Specification:** [TR-09-2 tags](tr-09-2.md)
 - **Applicability:** AMWA IS-04 since v1.0

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -39,12 +39,12 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| booking-id1 | A string that defines a unique identifier for a first booking | Any string not containing `:` |
-| resource-id1 | A string that defines a unique identifier for the NMOS resource within the first booking | Any string not containing `:` |
-| label1 | Optional string that gives a user-friendly label for the NMOS resource within the first booking | Any string not containing `:` |
-| booking-id2 | A string that defines a unique identifier for a second booking | Any string not containing `:` |
-| resource-id2 | A string that defines a unique identifier for the NMOS resource within the second booking | Any string not containing `:` |
-| label2 | Optional string that gives a user-friendly label for the NMOS resource within the second booking | Any string not containing `:` |
+| booking-id1 | A string that defines a unique identifier for a first booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
+| resource-id1 | A string that defines a unique identifier for the NMOS resource within the first booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
+| label1 | Optional string that gives a user-friendly label for the NMOS resource within the first booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric + hyphen, underscore and space) |
+| booking-id2 | A string that defines a unique identifier for a second booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
+| resource-id2 | A string that defines a unique identifier for the NMOS resource within the second booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
+| label2 | Optional string that gives a user-friendly label for the NMOS resource within the second booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric + hyphen, underscore and space) |
 | etc. | | |
 
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
@@ -71,7 +71,7 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| booking-id | The currently active booking from the booking list | Any string not containing `:`, MUST match one of the booking-id values in the booking list |
+| booking-id | The currently active booking from the booking list | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric + hyphen and underscore), MUST match one of the booking-id values in the booking list |
 
 No more than one `booking-id` MUST be listed in the current booking.
 

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -29,7 +29,7 @@ The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "{consumer-id}:{booking-id}:{resource-id}[:{label}]"
+      "{consumer-id}:{booking-id}:{element-name}[:{label}]"
    ]
 }
 ```
@@ -40,7 +40,7 @@ Where
 | --------- | ----------- | ------ |
 | `consumer-id` | A string that defines a unique identifier for a receiving facility | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
 | `booking-id` | A string that defines a unique identifier for a booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
-| `resource-id` | A string that defines a unique identifier for the resource within the booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
+| `element-name` | A string that defines a unique name for the resource within the booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
 | `label` | Optional string that gives a user-friendly label for the resource within the booking | `[-_a-zA-Z0-9 ]+$` (case insensitive alphanumeric, hyphen, underscore and space) |
 
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
@@ -48,17 +48,16 @@ The colon character, `:`, is reserved and MUST not be used in any of the paramet
 As defined in the VSF TR-09-2 specification:
  - The `consumer-id` SHOULD be provided by the facility *offering* the shared resource.
  - The `booking-id`, `resource-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
- - The `resource-id` MUST be unique to the TR-09-2 booking tags and MUST NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
- - The same `resource-id` MAY be used for a given resource across multiple bookings.
+ - The `element-name` MUST be unique to the TR-09-2 booking tags and MUST NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
+ - The same `element-name` MAY be used for a given resource across multiple bookings.
 
-Additionally: 
- - Where a shared resource has other associated shared resources on which it is dependent these MUST use the same `resource-id` (e.g. the Source and Flow associated with a Sender MUST both be given the same `resource-id` as the Sender).
- 
 ## Current Booking URN
 
 The current booking URN `urn:x-vsf:tag:tr-09-2:current-booking/v1.0` defines the currently active booking for the shared NMOS resource.
 
 If one of the bookings described in the booking list is active then the list MUST contain a single element identifying the active booking. Otherwise, the list MUST be empty.
+
+When the current booking ends, it MUST be removed from the current booking URN. Unless it is to be used again, it SHOULD also be removed from the booking list.
 
 ```json
 "tags": {
@@ -79,7 +78,7 @@ The `consumer-id` and `booking-id` MUST originate from the same element in the b
 
 ## Examples
 
-### 1. NMOS Sender, Source and Flow resources representing a camera with one booking which is currently active
+### 1. NMOS Sender representing a camera with one booking which is currently active
 
 JSON tags for Sender resource
 
@@ -94,33 +93,7 @@ JSON tags for Sender resource
 }
 ```
 
-JSON tags for Source resource (note that this shares the same `resource-id` as the Sender resource)
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0001"
-   ]
-}
-```
-
-JSON tags for Flow resource (note that this shares the same `resource-id` as the Sender resource)
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0001"
-   ]
-}
-```
-
-### 2. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, the second of which is currently active
+### 2. NMOS Sender representing a camera with multiple associated bookings, the second of which is currently active
 
 JSON tags for Sender resource
 
@@ -137,37 +110,7 @@ JSON tags for Sender resource
 }
 ```
 
-JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0002"
-   ]
-}
-```
-
-JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0002"
-   ]
-}
-```
-
-### 3. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings where the resource-id and label are the same across all bookings and the second booking is currently active
+### 3. NMOS Sender representing a camera with multiple associated bookings where the element-name and label are the same across all bookings and the second booking is currently active
 
 JSON tags for Sender resource
 
@@ -184,67 +127,9 @@ JSON tags for Sender resource
 }
 ```
 
-JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0002"
-   ]
-}
-```
-
-JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0002"
-   ]
-}
-```
-
-### 4. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, none of which is currently active
+### 4. NMOS Sender representing a camera with multiple associated bookings, none of which is currently active
 
 JSON tags for Sender resource
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-   ]
-}
-```
-
-JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
-
-```json
-"tags": {
-   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
-   ],
-   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-   ]
-}
-```
-
-JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
 
 ```json
 "tags": {

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -5,22 +5,22 @@
   - **Proponent:** [VSF](https://www.vsf.tv/)
 
 - **Name:**  urn:x-vsf:tag:tr-09-2:current-booking/v1.0
-  - **Description:** Current Booking tag that can be used to indicate that an NMOS resource is part of an active TR-09-2 booking.
+  - **Description:** Current Booking tag that can be used to indicate the current active TR-09-2 booking.
   - **Proponent:** [VSF](https://www.vsf.tv/)
 
 This document describes an application of the AMWA IS-04 `tags` structures to enable control systems to identify NMOS resources that are being shared across a facility boundary as described in the VSF TR-09-2 specification.
 
 ## Introduction
 
-The aim of the TR-09-2 booking tags is to facilitate the sharing of NMOS resources between two completely independent media facilities.
+The aim of the TR-09-2 booking tags is to facilitate the sharing of NMOS resources between two independent media facilities.
 
 The tags contain information that allows an NMOS resource to be identified and matched to information defined during an earlier booking process.
 
 This booking process takes place between the facility offering the shared resource and the facility consuming the shared resource, as defined in the VSF TR-09-2 specification document.
 
-Two sets of tags are defined: the booking list tags and the current booking tags.
+Two TR-09-2 tags are defined: the `booking-list` tag and the `current-booking` tag.
 
-[TODO: add description of who uses the information in the tags]
+When an NMOS resource is to be shared with another facility, the facility offering the shared resource MUST include these tags in the JSON of the NMOS resource at the point it is made available at the facility edge.
 
 ## Booking List URN
 
@@ -50,13 +50,14 @@ Where
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
 
 As defined in the VSF TR-09-1 specification:
- - the booking-id is provided by the facility consuming the shared resource
- - the resource-id and label are provided by the facility offering the shared resource
- - the resource-id should be unique to the TR-09-2 booking and MUST not be the same as any existing NMOS UUID associated with the resource
+ - the `booking-id` SHOULD be provided by the facility consuming the shared resource
+ - the `resource-id` and `label` SHOULD be provided by the facility offering the shared resource
+ - the `resource-id` MUST be unique to the TR-09-2 booking tags and MUST not be the same as the NMOS UUID associated with the resource (from the resource's `id` field)
+ - the same `resource-id` MAY be used for a given NMOS resource across multiple bookings
  
 ## Current Booking URN
 
-The current booking URN `urn:x-vsf:tag:tr-09-2:current-booking/v1.0` defines the currently active booking for the shared NMOS resource. If none of the bookings in the booking list is currently active, then this tag MUST be omitted.
+The current booking URN `urn:x-vsf:tag:tr-09-2:current-booking/v1.0` defines the currently active booking for the shared NMOS resource. If none of the bookings in the booking list is currently active, then the list MUST be empty.
 
 ```json
 "tags": {
@@ -72,16 +73,114 @@ Where
 | --------- | ----------- | ------ |
 | booking-id | The currently active booking from the booking list | Any string not containing `:`, MUST match one of the booking-id values in the booking list |
 
-Only one booking-id is ever listed in the current booking.
+No more than one `booking-id` MUST be listed in the current booking.
 
 ## Examples
 
-[TODO: add examples]
+### 1. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, the first of which is currently active
+JSON tags for Sender resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
+      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
+      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Studio Camera]",
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0001"
+   ]
+}
+```
 
+JSON tags for Source resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:68d3d2ec-827a-11ec-a8a3-0242ac120002:Main Camera]",
+      "Booking0002:68d3d2ec-827a-11ec-a8a3-0242ac120002:Main Camera]",
+      "Booking0003:e50a4e97-938f-42c4-b033-4180ed0a013e:Studio Camera]",
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0001"
+   ]
+}
+```
 
-## NMOS resource JSON samples
+JSON tags for Flow resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:84b35090-827b-11ec-a8a3-0242ac120002:Main Camera]",
+      "Booking0002:84b35090-827b-11ec-a8a3-0242ac120002:Main Camera]",
+      "Booking0003:1622f58d-5775-4a84-bad8-c22fcce13832:Studio Camera]",
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0001"
+   ]
+}
+```
 
-[TODO: add sample JSON]
+### 2. NMOS Sender, Source and Flow resources representing a camera with just one associated booking which is not currently active
+JSON tags for Sender resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+   ]
+}
+```
+JSON tags for Source resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:68d3d2ec-827a-11ec-a8a3-0242ac120002:Main Camera]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+   ]
+}
+```
 
-Senders with tags
+JSON tags for Flow resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:84b35090-827b-11ec-a8a3-0242ac120002:Main Camera]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+   ]
+}
+```
 
+## NMOS resource JSON sample
+
+Sender with tags from first example above
+
+```json
+{
+   "format": "urn:x-nmos:format:video",
+   "caps": {},
+   "device_id": "8570e409-eb39-4c28-b083-fb2be5d44abe",
+   "transport": "urn:x-nmos:transport:rtp.mcast",
+   "interface_bindings": [],
+   "subscription": {
+      "sender_id": null,
+      "active": true
+   },
+   "id": "51e6b7ef-7061-4121-b8d3-426527d3ac4f",
+   "version": "1525121173:668000000",
+   "label": "H200-11B Camera",
+   "description": "High definition broadcast camera",
+   "tags": {
+      "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+         "Booking0001:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
+         "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
+         "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Studio Camera]",
+      ],
+      "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+         "Booking0001"
+      ]
+   }
+}
+```

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -29,7 +29,7 @@ The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "{consumer-id}:{booking-id}:{element-name}[:{label}]"
+      "{consumer-id}:{booking-id}:{element-id}[:{label}]"
    ]
 }
 ```
@@ -40,7 +40,7 @@ Where
 | --------- | ----------- | ------ |
 | `consumer-id` | A string that defines a unique identifier for a receiving facility | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
 | `booking-id` | A string that defines a unique identifier for a booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
-| `element-name` | A string that defines a unique name for the resource within the booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
+| `element-id` | A string that defines a unique identifier for the resource within the booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
 | `label` | Optional string that gives a user-friendly label for the resource within the booking | `[-_a-zA-Z0-9 ]+$` (case insensitive alphanumeric, hyphen, underscore and space) |
 
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
@@ -48,8 +48,8 @@ The colon character, `:`, is reserved and MUST not be used in any of the paramet
 As defined in the VSF TR-09-2 specification:
  - The `consumer-id` SHOULD be provided by the facility *offering* the shared resource.
  - The `booking-id`, `resource-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
- - The `element-name` MUST be unique to the TR-09-2 booking tags and MUST NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
- - The same `element-name` MAY be used for a given resource across multiple bookings.
+ - The `element-id` MUST be unique to the TR-09-2 booking tags and MUST NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
+ - The same `element-id` MAY be used for a given resource across multiple bookings.
 
 ## Current Booking URN
 
@@ -110,7 +110,7 @@ JSON tags for Sender resource
 }
 ```
 
-### 3. NMOS Sender representing a camera with multiple associated bookings where the element-name and label are the same across all bookings and the second booking is currently active
+### 3. NMOS Sender representing a camera with multiple associated bookings where the element-id and label are the same across all bookings and the second booking is currently active
 
 JSON tags for Sender resource
 

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -29,7 +29,7 @@ The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "{consumer-id}:{booking-id}:{element-id}[:{label}]"
+      "{consumer-id}:{booking-id}:{element-id}:[{label}]"
    ]
 }
 ```
@@ -38,24 +38,24 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| `consumer-id` | A string that defines a unique identifier for a receiving facility | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
-| `booking-id` | A string that defines a unique identifier for a booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
-| `element-id` | A string that defines a unique identifier for the resource within the booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
-| `label` | Optional string that gives a user-friendly label for the resource within the booking | `[-_a-zA-Z0-9 ]+$` (case insensitive alphanumeric, hyphen, underscore and space) |
+| `consumer-id` | A string that defines a unique identifier for the receiving facility | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
+| `booking-id` | A string that defines a unique identifier for the booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
+| `element-id` | A string that defines a unique identifier for the resource within the booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
+| `label` | A string that defines a user-friendly label for the resource within the booking | `^[^:]{0,128}$` (any string not containing `:`, MAY be empty) |
 
-The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
+The colon character, `:`, is reserved and MUST NOT be used in any of the parameters listed.
 
 As defined in the VSF TR-09-2 specification:
  - The `consumer-id` SHOULD be provided by the facility *offering* the shared resource.
- - The `booking-id`, `resource-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
- - The `element-id` MUST be unique to the TR-09-2 booking tags and MUST NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
+ - The `booking-id`, `element-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
+ - The `element-id` MUST be unique to the TR-09-2 booking tags and SHOULD NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
  - The same `element-id` MAY be used for a given resource across multiple bookings.
 
 ## Current Booking URN
 
 The current booking URN `urn:x-vsf:tag:tr-09-2:current-booking/v1.0` defines the currently active booking for the shared NMOS resource.
 
-If one of the bookings described in the booking list is active then the list MUST contain a single element identifying the active booking. Otherwise, the list MUST be empty.
+If one of the bookings described in the booking list is active then the list MUST contain a single entry identifying the active booking. Otherwise, the list MUST be empty.
 
 When the current booking ends, it MUST be removed from the current booking URN. Unless it is to be used again, it SHOULD also be removed from the booking list.
 
@@ -71,10 +71,10 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| `consumer-id` | The `consumer-id` parameter associated with the currently active booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
-| `booking-id` | The `booking-id` parameter associated with the currently active booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
+| `consumer-id` | The `consumer-id` parameter associated with the currently active booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
+| `booking-id` | The `booking-id` parameter associated with the currently active booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
 
-The `consumer-id` and `booking-id` MUST originate from the same element in the booking list.
+The `consumer-id` and `booking-id` MUST originate from the same entry in the booking list.
 
 ## Examples
 
@@ -85,10 +85,10 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera"
+      "consumer_a:booking0001:camera-1:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0001"
+      "consumer_a:booking0001"
    ]
 }
 ```
@@ -100,12 +100,12 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
+      "consumer_a:booking0001:camera-1:Main Camera",
+      "consumer_a:booking0002:camera-studio:Studio Camera",
+      "consumer_a:booking0003:camera-2:Camera 2"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0002"
+      "consumer_a:booking0002"
    ]
 }
 ```
@@ -117,12 +117,12 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera"
+      "consumer_a:booking0001:camera-1:Main Camera",
+      "consumer_a:booking0002:camera-1:Main Camera",
+      "consumer_a:booking0003:camera-1:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "ConsumerA:Booking0002"
+      "consumer_a:booking0002"
    ]
 }
 ```
@@ -134,9 +134,9 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
+      "consumer_a:booking0001:camera-1:Main Camera",
+      "consumer_a:booking0002:camera-1:Main Camera",
+      "consumer_a:booking0003:camera-1:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
@@ -164,12 +164,12 @@ Sender with tags from example 2 above
    "description": "High definition broadcast camera",
    "tags": {
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-         "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
-         "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
-         "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
+         "consumer_a:booking0001:camera-1:Main Camera",
+         "consumer_a:booking0002:camera-studio:Studio Camera",
+         "consumer_a:booking0003:camera-2:Camera 2"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-         "ConsumerA:Booking0002"
+         "consumer_a:booking0002"
       ]
    }
 }
@@ -194,10 +194,10 @@ A second Sender that is part of the same active booking but has no other booking
    "description": "High definition broadcast camera",
    "tags": {
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-         "ConsumerA:Booking0002:665e136d-65b4-4ce5-a1a0-99270857c993:Reserve Camera"
+         "consumer_a:booking0002:camera-3:Reserve Camera"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-         "ConsumerA:Booking0002"
+         "consumer_a:booking0002"
       ]
    }
 }

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -162,7 +162,7 @@ Sender with tags from first example above
    "format": "urn:x-nmos:format:video",
    "caps": {},
    "device_id": "8570e409-eb39-4c28-b083-fb2be5d44abe",
-   "transport": "urn:x-nmos:transport:rtp.mcast",
+   "transport": "urn:x-nmos:transport:rtp.ucast",
    "interface_bindings": [],
    "subscription": {
       "sender_id": null,

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -29,7 +29,7 @@ The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "{booking-id}:{resource-id}[:{label}]"
+      "{consumer-id}:{booking-id}:{resource-id}[:{label}]"
    ]
 }
 ```
@@ -38,29 +38,32 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| booking-id | A string that defines a unique identifier for a booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
-| resource-id | A string that defines a unique identifier for the resource within the booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
-| label | Optional string that gives a user-friendly label for the resource within the booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric, hyphen, underscore and space) |
+| `consumer-id` | A string that defines a unique identifier for a receiving facility | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
+| `booking-id` | A string that defines a unique identifier for a booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
+| `resource-id` | A string that defines a unique identifier for the resource within the booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
+| `label` | Optional string that gives a user-friendly label for the resource within the booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric, hyphen, underscore and space) |
 
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
 
 As defined in the VSF TR-09-1 specification:
- - the `booking-id` SHOULD be provided by the facility consuming the shared resource
- - the `resource-id` and `label` SHOULD be provided by the facility offering the shared resource
- - the `resource-id` MUST be unique to the TR-09-2 booking tags and MUST not be the same as the NMOS UUID associated with the resource (from the resource's `id` field)
- - the same `resource-id` MAY be used for a given resource across multiple bookings
+ - The `consumer-id` SHOULD be provided by the facility *offering* the shared resource.
+ - The `booking-id`, `resource-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
+ - The `resource-id` MUST be unique to the TR-09-2 booking tags and MUST NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
+ - The same `resource-id` MAY be used for a given resource across multiple bookings.
 
 Additionally: 
- - where a shared resource has other associated shared resources on which it is dependent these MUST use the same `resource-id` (e.g. the Source and Flow associated with a Sender MUST both be given the same `resource-id` as the Sender)
+ - Where a shared resource has other associated shared resources on which it is dependent these MUST use the same `resource-id` (e.g. the Source and Flow associated with a Sender MUST both be given the same `resource-id` as the Sender).
  
 ## Current Booking URN
 
-The current booking URN `urn:x-vsf:tag:tr-09-2:current-booking/v1.0` defines the currently active booking for the shared NMOS resource. If none of the bookings in the booking list is currently active, then the list MUST be empty.
+The current booking URN `urn:x-vsf:tag:tr-09-2:current-booking/v1.0` defines the currently active booking for the shared NMOS resource.
+
+If one of the bookings described in the booking list is active then the list MUST contain a single element identifying the active booking. Otherwise, the list MUST be empty.
 
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "{booking-id}"
+      "{consumer-id}:{booking-id}"
    ]
 }
 ```
@@ -69,9 +72,10 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| booking-id | The currently active booking from the booking list | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric, hyphen and underscore), MUST match one of the booking-id values in the booking list |
+| `consumer-id` | The `consumer-id` parameter associated with the currently active booking | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric, hyphen and underscore) |
+| `booking-id` | The `booking-id` parameter associated with the currently active booking | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric, hyphen and underscore) |
 
-No more than one `booking-id` MUST be listed in the current booking.
+The `consumer-id` and `booking-id` MUST originate from the same element in the booking list.
 
 ## Examples
 
@@ -80,10 +84,10 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
+      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0001"
+      "ConsumerA:Booking0001"
    ]
 }
 ```
@@ -92,10 +96,10 @@ JSON tags for Source resource (note that this shares the same `resource-id` as t
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
+      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0001"
+      "ConsumerA:Booking0001"
    ]
 }
 ```
@@ -104,10 +108,10 @@ JSON tags for Flow resource (note that this shares the same `resource-id` as the
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Wide Angle View Camera]"
+      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Wide Angle View Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0001"
+      "ConsumerA:Booking0001"
    ]
 }
 ```
@@ -117,12 +121,12 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0002"
+      "ConsumerA:Booking0002"
    ]
 }
 ```
@@ -131,12 +135,12 @@ JSON tags for Source resource (note that this shares the same `resource-id`s as 
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0002"
+      "ConsumerA:Booking0002"
    ]
 }
 ```
@@ -145,12 +149,12 @@ JSON tags for Flow resource (note that this shares the same `resource-id`s as th
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0002"
+      "ConsumerA:Booking0002"
    ]
 }
 ```
@@ -160,12 +164,12 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0002"
+      "ConsumerA:Booking0002"
    ]
 }
 ```
@@ -174,12 +178,12 @@ JSON tags for Source resource (note that this shares the same `resource-id`s as 
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0002"
+      "ConsumerA:Booking0002"
    ]
 }
 ```
@@ -188,12 +192,12 @@ JSON tags for Flow resource (note that this shares the same `resource-id`s as th
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "Booking0002"
+      "ConsumerA:Booking0002"
    ]
 }
 ```
@@ -203,9 +207,9 @@ JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
@@ -215,9 +219,9 @@ JSON tags for Source resource (note that this shares the same `resource-id`s as 
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
@@ -228,9 +232,9 @@ JSON tags for Flow resource (note that this shares the same `resource-id`s as th
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
@@ -258,12 +262,12 @@ Sender with tags from example 2 above
    "description": "High definition broadcast camera",
    "tags": {
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-         "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-         "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-         "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+         "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+         "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+         "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-         "Booking0002"
+         "ConsumerA:Booking0002"
       ]
    }
 }
@@ -288,10 +292,10 @@ A second Sender that is part of the same active booking but has no other booking
    "description": "High definition broadcast camera",
    "tags": {
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-         "Booking0002:665e136d-65b4-4ce5-a1a0-99270857c993:Reserve Camera]"
+         "ConsumerA:Booking0002:665e136d-65b4-4ce5-a1a0-99270857c993:Reserve Camera]"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-         "Booking0002"
+         "ConsumerA:Booking0002"
       ]
    }
 }

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -1,0 +1,87 @@
+# TR-09-2 Booking Tags
+
+- **Name:**  urn:x-vsf:tag:tr-09-2:booking-list/v1.0
+  - **Description:** Booking List tag that can be used to indicate that an NMOS resource is part of one or more TR-09-2 bookings.
+  - **Proponent:** [VSF](https://www.vsf.tv/)
+
+- **Name:**  urn:x-vsf:tag:tr-09-2:current-booking/v1.0
+  - **Description:** Current Booking tag that can be used to indicate that an NMOS resource is part of an active TR-09-2 booking.
+  - **Proponent:** [VSF](https://www.vsf.tv/)
+
+This document describes an application of the AMWA IS-04 `tags` structures to enable control systems to identify NMOS resources that are being shared across a facility boundary as described in the VSF TR-09-2 specification.
+
+## Introduction
+
+The aim of the TR-09-2 booking tags is to facilitate the sharing of NMOS resources between two completely independent media facilities.
+
+The tags contain information that allows an NMOS resource to be identified and matched to information defined during an earlier booking process.
+
+This booking process takes place between the facility offering the shared resource and the facility consuming the shared resource, as defined in the VSF TR-09-2 specification document.
+
+Two sets of tags are defined: the booking list tags and the current booking tags.
+
+[TODO: add description of who uses the information in the tags]
+
+## Booking List URN
+
+The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of bookings associated with the shared NMOS resource.
+
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "{booking-id1}:{resource-id1}[:{label1}]",
+      "{booking-id2}:{resource-id2}[:{label2}]"
+   ]
+}
+```
+
+Where
+
+| Parameter | Description | Values |
+| --------- | ----------- | ------ |
+| booking-id1 | A string that defines a unique identifier for a first booking | Any string not containing `:` |
+| resource-id1 | A string that defines a unique identifier for the NMOS resource within the first booking | Any string not containing `:` |
+| label1 | Optional string that gives a user-friendly label for the NMOS resource within the first booking | Any string not containing `:` |
+| booking-id2 | A string that defines a unique identifier for a second booking | Any string not containing `:` |
+| resource-id2 | A string that defines a unique identifier for the NMOS resource within the second booking | Any string not containing `:` |
+| label2 | Optional string that gives a user-friendly label for the NMOS resource within the second booking | Any string not containing `:` |
+| etc. | | |
+
+The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
+
+As defined in the VSF TR-09-1 specification:
+ - the booking-id is provided by the facility consuming the shared resource
+ - the resource-id and label are provided by the facility offering the shared resource
+ - the resource-id should be unique to the TR-09-2 booking and MUST not be the same as any existing NMOS UUID associated with the resource
+ 
+## Current Booking URN
+
+The current booking URN `urn:x-vsf:tag:tr-09-2:current-booking/v1.0` defines the currently active booking for the shared NMOS resource. If none of the bookings in the booking list is currently active, then this tag MUST be omitted.
+
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "{booking-id}"
+   ]
+}
+```
+
+Where
+
+| Parameter | Description | Values |
+| --------- | ----------- | ------ |
+| booking-id | The currently active booking from the booking list | Any string not containing `:`, MUST match one of the booking-id values in the booking list |
+
+Only one booking-id is ever listed in the current booking.
+
+## Examples
+
+[TODO: add examples]
+
+
+## NMOS resource JSON samples
+
+[TODO: add sample JSON]
+
+Senders with tags
+

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -198,7 +198,7 @@ JSON tags for Flow resource (note that this shares the same `resource-id`s as th
 }
 ```
 
-### 4. NMOS Sender, Source and Flow resources representing a camera with with multiple associated bookings, none of which is currently active
+### 4. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, none of which is currently active
 JSON tags for Sender resource
 ```json
 "tags": {
@@ -239,7 +239,7 @@ JSON tags for Flow resource (note that this shares the same `resource-id`s as th
 
 ## NMOS resource JSON samples
 
-Sender with tags from second example 2 above
+Sender with tags from example 2 above
 
 ```json
 {

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -29,26 +29,28 @@ The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "{consumer-id}:{booking-id}:{element-id}:[{label}]"
+      "<consumer-id>:<booking-id>:<element-id>[:<label>]"
    ]
 }
 ```
 
-Where
+Where `<`...`>` indicates a named parameter and `[`...`]` indicates an optional component of the string.
+Several examples are given below.
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| `consumer-id` | A string that defines a unique identifier for the receiving facility | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
-| `booking-id` | A string that defines a unique identifier for the booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
-| `element-id` | A string that defines a unique identifier for the resource within the booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
-| `label` | A string that defines a user-friendly label for the resource within the booking | `^[^:]{0,128}$` (any string not containing `:`, MAY be empty) |
+| `consumer-id` | A unique identifier for the receiving facility | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
+| `booking-id` | A unique identifier for the booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
+| `element-id` | A unique identifier for the resource within the booking | `^[-_a-z0-9]{1,64}$` (lower case alphanumeric, hyphen and underscore) |
+| `label` | A user-friendly label for the resource within the booking | `^[^:]{1,128}$` (any string not containing `:`) |
 
 The colon character, `:`, is reserved and MUST NOT be used in any of the parameters listed.
 
 As defined in the VSF TR-09-2 specification:
  - The `consumer-id` SHOULD be provided by the facility *offering* the shared resource.
  - The `booking-id`, `element-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
- - The `element-id` MUST be unique to the TR-09-2 booking tags and SHOULD NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
+ - The `element-id` MUST be unique within a booking (as identified by `<consumer-id>:<booking-id>`).
+ - The `element-id` SHOULD NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
  - The same `element-id` MAY be used for a given resource across multiple bookings.
 
 ## Current Booking URN
@@ -62,7 +64,7 @@ When the current booking ends, it MUST be removed from the current booking URN. 
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-      "{consumer-id}:{booking-id}"
+      "<consumer-id>:<booking-id>"
    ]
 }
 ```
@@ -166,7 +168,7 @@ Sender with tags from example 2 above
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
          "consumer_a:booking0001:camera-1:Main Camera",
          "consumer_a:booking0002:camera-studio:Studio Camera",
-         "consumer_a:booking0003:camera-2:Camera 2"
+         "consumer_a:booking0003:camera-2"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
          "consumer_a:booking0002"

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -24,13 +24,12 @@ When an NMOS resource is to be shared with another facility, the facility offeri
 
 ## Booking List URN
 
-The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of bookings associated with the shared NMOS resource.
+The booking list URN `urn:x-vsf:tag:tr-09-2:booking-list/v1.0` defines a list of bookings associated with the shared NMOS resource. It is defined by an array containing a list of one or more bookings.
 
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "{booking-id1}:{resource-id1}[:{label1}]",
-      "{booking-id2}:{resource-id2}[:{label2}]"
+      "{booking-id}:{resource-id}[:{label}]"
    ]
 }
 ```
@@ -39,13 +38,9 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| booking-id1 | A string that defines a unique identifier for a first booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
-| resource-id1 | A string that defines a unique identifier for the NMOS resource within the first booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
-| label1 | Optional string that gives a user-friendly label for the NMOS resource within the first booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric + hyphen, underscore and space) |
-| booking-id2 | A string that defines a unique identifier for a second booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
-| resource-id2 | A string that defines a unique identifier for the NMOS resource within the second booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric + hyphen and underscore) |
-| label2 | Optional string that gives a user-friendly label for the NMOS resource within the second booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric + hyphen, underscore and space) |
-| etc. | | |
+| booking-id | A string that defines a unique identifier for a booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
+| resource-id | A string that defines a unique identifier for the resource within the booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
+| label | Optional string that gives a user-friendly label for the resource within the booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric, hyphen, underscore and space) |
 
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
 
@@ -53,7 +48,10 @@ As defined in the VSF TR-09-1 specification:
  - the `booking-id` SHOULD be provided by the facility consuming the shared resource
  - the `resource-id` and `label` SHOULD be provided by the facility offering the shared resource
  - the `resource-id` MUST be unique to the TR-09-2 booking tags and MUST not be the same as the NMOS UUID associated with the resource (from the resource's `id` field)
- - the same `resource-id` MAY be used for a given NMOS resource across multiple bookings
+ - the same `resource-id` MAY be used for a given resource across multiple bookings
+
+Additionally: 
+ - where a shared resource has other associated shared resources on which it is dependent these MUST use the same `resource-id` (e.g. the Source and Flow associated with a Sender MUST both be given the same `resource-id` as the Sender)
  
 ## Current Booking URN
 
@@ -71,20 +69,18 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| booking-id | The currently active booking from the booking list | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric + hyphen and underscore), MUST match one of the booking-id values in the booking list |
+| booking-id | The currently active booking from the booking list | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric, hyphen and underscore), MUST match one of the booking-id values in the booking list |
 
 No more than one `booking-id` MUST be listed in the current booking.
 
 ## Examples
 
-### 1. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, the first of which is currently active
+### 1. NMOS Sender, Source and Flow resources representing a camera with one booking which is currently active
 JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
-      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
-      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Studio Camera]",
+      "Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "Booking0001"
@@ -92,13 +88,11 @@ JSON tags for Sender resource
 }
 ```
 
-JSON tags for Source resource
+JSON tags for Source resource (note that this shares the same `resource-id` as the Sender resource)
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:68d3d2ec-827a-11ec-a8a3-0242ac120002:Main Camera]",
-      "Booking0002:68d3d2ec-827a-11ec-a8a3-0242ac120002:Main Camera]",
-      "Booking0003:e50a4e97-938f-42c4-b033-4180ed0a013e:Studio Camera]",
+      "Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "Booking0001"
@@ -106,13 +100,11 @@ JSON tags for Source resource
 }
 ```
 
-JSON tags for Flow resource
+JSON tags for Flow resource (note that this shares the same `resource-id` as the Sender resource)
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:84b35090-827b-11ec-a8a3-0242ac120002:Main Camera]",
-      "Booking0002:84b35090-827b-11ec-a8a3-0242ac120002:Main Camera]",
-      "Booking0003:1622f58d-5775-4a84-bad8-c22fcce13832:Studio Camera]",
+      "Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Wide Angle View Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "Booking0001"
@@ -120,42 +112,134 @@ JSON tags for Flow resource
 }
 ```
 
-### 2. NMOS Sender, Source and Flow resources representing a camera with just one associated booking which is not currently active
+### 2. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, the second of which is currently active
 JSON tags for Sender resource
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]"
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0002"
    ]
 }
 ```
-JSON tags for Source resource
+
+JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:68d3d2ec-827a-11ec-a8a3-0242ac120002:Main Camera]"
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0002"
    ]
 }
 ```
 
-JSON tags for Flow resource
+JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "Booking0001:84b35090-827b-11ec-a8a3-0242ac120002:Main Camera]"
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0002"
+   ]
+}
+```
+
+### 3. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings where the resource-id and label are the same across all bookings and the second booking is currently active
+JSON tags for Sender resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0002"
+   ]
+}
+```
+
+JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0002"
+   ]
+}
+```
+
+JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+      "Booking0002"
+   ]
+}
+```
+
+### 4. NMOS Sender, Source and Flow resources representing a camera with with multiple associated bookings, none of which is currently active
+JSON tags for Sender resource
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+   ]
+}
+```
+JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
 }
 ```
 
-## NMOS resource JSON sample
+JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
+```json
+"tags": {
+   "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+      "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+      "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+      "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+   ],
+   "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+   ]
+}
+```
 
-Sender with tags from first example above
+## NMOS resource JSON samples
+
+Sender with tags from second example 2 above
 
 ```json
 {
@@ -174,12 +258,40 @@ Sender with tags from first example above
    "description": "High definition broadcast camera",
    "tags": {
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-         "Booking0001:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
-         "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Main Camera]",
-         "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Studio Camera]",
+         "Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
+         "Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
+         "Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
-         "Booking0001"
+         "Booking0002"
+      ]
+   }
+}
+```
+
+A second Sender that is part of the same active booking but has no other bookings
+
+```json
+{
+   "format": "urn:x-nmos:format:video",
+   "caps": {},
+   "device_id": "8570e409-eb39-4c28-b083-fb2be5d44abe",
+   "transport": "urn:x-nmos:transport:rtp.ucast",
+   "interface_bindings": [],
+   "subscription": {
+      "sender_id": null,
+      "active": true
+   },
+   "id": "51e6b7ef-7061-4121-b8d3-426527d3ac4f",
+   "version": "1525121173:668000000",
+   "label": "H200-11B Camera",
+   "description": "High definition broadcast camera",
+   "tags": {
+      "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
+         "Booking0002:665e136d-65b4-4ce5-a1a0-99270857c993:Reserve Camera]"
+      ],
+      "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
+         "Booking0002"
       ]
    }
 }

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -45,7 +45,7 @@ Where
 
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
 
-As defined in the VSF TR-09-1 specification:
+As defined in the VSF TR-09-2 specification:
  - The `consumer-id` SHOULD be provided by the facility *offering* the shared resource.
  - The `booking-id`, `resource-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
  - The `resource-id` MUST be unique to the TR-09-2 booking tags and MUST NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
@@ -108,7 +108,7 @@ JSON tags for Flow resource (note that this shares the same `resource-id` as the
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Wide Angle View Camera]"
+      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0001"
@@ -286,7 +286,7 @@ A second Sender that is part of the same active booking but has no other booking
       "sender_id": null,
       "active": true
    },
-   "id": "51e6b7ef-7061-4121-b8d3-426527d3ac4f",
+   "id": "1b990a6b-5cf4-4639-8e50-c6055182b149",
    "version": "1525121173:668000000",
    "label": "H200-11B Camera",
    "description": "High definition broadcast camera",

--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -38,10 +38,10 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| `consumer-id` | A string that defines a unique identifier for a receiving facility | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
-| `booking-id` | A string that defines a unique identifier for a booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
-| `resource-id` | A string that defines a unique identifier for the resource within the booking | ^[-_a-zA-Z0-9]+$ (case insensitive alphanumeric, hyphen and underscore) |
-| `label` | Optional string that gives a user-friendly label for the resource within the booking | ^[-_a-zA-Z0-9 ]+$ (case insensitive alphanumeric, hyphen, underscore and space) |
+| `consumer-id` | A string that defines a unique identifier for a receiving facility | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
+| `booking-id` | A string that defines a unique identifier for a booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
+| `resource-id` | A string that defines a unique identifier for the resource within the booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
+| `label` | Optional string that gives a user-friendly label for the resource within the booking | `[-_a-zA-Z0-9 ]+$` (case insensitive alphanumeric, hyphen, underscore and space) |
 
 The colon character, `:`, is reserved and MUST not be used in any of the parameters listed.
 
@@ -72,19 +72,21 @@ Where
 
 | Parameter | Description | Values |
 | --------- | ----------- | ------ |
-| `consumer-id` | The `consumer-id` parameter associated with the currently active booking | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric, hyphen and underscore) |
-| `booking-id` | The `booking-id` parameter associated with the currently active booking | ^[-_a-zA-Z0-9]+$ (Case insensitive alphanumeric, hyphen and underscore) |
+| `consumer-id` | The `consumer-id` parameter associated with the currently active booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
+| `booking-id` | The `booking-id` parameter associated with the currently active booking | `^[-_a-zA-Z0-9]+$` (case insensitive alphanumeric, hyphen and underscore) |
 
 The `consumer-id` and `booking-id` MUST originate from the same element in the booking list.
 
 ## Examples
 
 ### 1. NMOS Sender, Source and Flow resources representing a camera with one booking which is currently active
+
 JSON tags for Sender resource
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
+      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0001"
@@ -93,10 +95,11 @@ JSON tags for Sender resource
 ```
 
 JSON tags for Source resource (note that this shares the same `resource-id` as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
+      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0001"
@@ -105,10 +108,11 @@ JSON tags for Source resource (note that this shares the same `resource-id` as t
 ```
 
 JSON tags for Flow resource (note that this shares the same `resource-id` as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera]"
+      "ConsumerA:Booking0001:a04e9401-f86d-4c97-a2c4-69c78594f723:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0001"
@@ -117,13 +121,15 @@ JSON tags for Flow resource (note that this shares the same `resource-id` as the
 ```
 
 ### 2. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, the second of which is currently active
+
 JSON tags for Sender resource
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0002"
@@ -132,12 +138,13 @@ JSON tags for Sender resource
 ```
 
 JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0002"
@@ -146,12 +153,13 @@ JSON tags for Source resource (note that this shares the same `resource-id`s as 
 ```
 
 JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0002"
@@ -160,13 +168,15 @@ JSON tags for Flow resource (note that this shares the same `resource-id`s as th
 ```
 
 ### 3. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings where the resource-id and label are the same across all bookings and the second booking is currently active
+
 JSON tags for Sender resource
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0002"
@@ -175,12 +185,13 @@ JSON tags for Sender resource
 ```
 
 JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0002"
@@ -189,12 +200,13 @@ JSON tags for Source resource (note that this shares the same `resource-id`s as 
 ```
 
 JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0003:54aab493-1765-4cea-a095-c87a81634daa:Main Camera"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
       "ConsumerA:Booking0002"
@@ -203,25 +215,29 @@ JSON tags for Flow resource (note that this shares the same `resource-id`s as th
 ```
 
 ### 4. NMOS Sender, Source and Flow resources representing a camera with multiple associated bookings, none of which is currently active
+
 JSON tags for Sender resource
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
 }
 ```
+
 JSON tags for Source resource (note that this shares the same `resource-id`s as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
@@ -229,12 +245,13 @@ JSON tags for Source resource (note that this shares the same `resource-id`s as 
 ```
 
 JSON tags for Flow resource (note that this shares the same `resource-id`s as the Sender resource)
+
 ```json
 "tags": {
    "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+      "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+      "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
+      "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
    ],
    "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
    ]
@@ -262,9 +279,9 @@ Sender with tags from example 2 above
    "description": "High definition broadcast camera",
    "tags": {
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-         "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera]",
-         "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera]",
-         "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2]"
+         "ConsumerA:Booking0001:54aab493-1765-4cea-a095-c87a81634daa:Main Camera",
+         "ConsumerA:Booking0002:2e3b3b5c-827a-11ec-a8a3-0242ac120002:Studio Camera",
+         "ConsumerA:Booking0003:8a63bf02-3d6e-47cd-a963-c17f43da7d47:Camera 2"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
          "ConsumerA:Booking0002"
@@ -292,7 +309,7 @@ A second Sender that is part of the same active booking but has no other booking
    "description": "High definition broadcast camera",
    "tags": {
       "urn:x-vsf:tag:tr-09-2:booking-list/v1.0": [
-         "ConsumerA:Booking0002:665e136d-65b4-4ce5-a1a0-99270857c993:Reserve Camera]"
+         "ConsumerA:Booking0002:665e136d-65b4-4ce5-a1a0-99270857c993:Reserve Camera"
       ],
       "urn:x-vsf:tag:tr-09-2:current-booking/v1.0": [
          "ConsumerA:Booking0002"


### PR DESCRIPTION
This PR adds a description of how IS-04 tags may be used to facilitate sharing of resources between facilities, as defined in the VSF TR-09-2 document drafted by the VSF's ST 2110 over WAN activity group.