### PR TITLE
Add JPEG XS packetization and transmission mode

### DIFF
--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -235,6 +235,14 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
   - **Target:** SDP attribute `a=maxptime:` `<maximum packet time>`
 - **Applicability:** AMWA IS-04
 
+### Packet Transmission Mode
+- **Name:** `urn:x-nmos:cap:transport:packet_transmission_mode`
+- **Description:** Identifies the acceptable JPEG XS packetization and transmission mode.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per the [Sender Attributes](../sender-attributes/#packet-transmission-mode) register)
+  - **Target:** (a) Sender `packet_transmission_mode` (defined in the Sender Attributes register), (b) SDP attribute `a=fmtp:` format-specific parameters `packetmode` and `transmode`, per [RFC 9134][RFC-9134]
+- **Applicability:** AMWA IS-04
+
 ### ST 2110-21 Sender Type
 - **Name:** `urn:x-nmos:cap:transport:st2110_21_sender_type`
 - **Description:** Identifies the ST 2110-21 receiver capabilities, expressed as the acceptable sender type or types.
@@ -244,4 +252,5 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
 - **Applicability:** AMWA IS-04
 
 [RFC-4566]: https://tools.ietf.org/html/rfc4566 "SDP: Session Description Protocol"
+[RFC-9134]: https://tools.ietf.org/html/rfc9134 "RTP Payload Format for ISO/IEC 21122 (JPEG XS)"
 [color-sampling]: https://www.iana.org/assignments/media-type-sub-parameters/media-type-sub-parameters.xhtml#media-type-sub-parameters-15 "Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling"

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -78,6 +78,9 @@
     "urn:x-nmos:cap:transport:max_packet_time": {
       "$ref": "param_constraint_number.json"
     },
+    "urn:x-nmos:cap:transport:packet_transmission_mode": {
+      "$ref": "param_constraint_string.json"
+    },
     "urn:x-nmos:cap:transport:st2110_21_sender_type": {
       "$ref": "param_constraint_string.json"
     }

--- a/sender-attributes/README.md
+++ b/sender-attributes/README.md
@@ -35,6 +35,18 @@ These MAY be used in addition to the schema, _sender.json_, found in the AMWA IS
   - Since AMWA IS-04 v1.3, integer values expressed in units of 1000 bits per second, rounding up
   - The value is for the IP packets, including the RTP, UDP and IP packet headers and the payload
 
+### Packet Transmission Mode
+- **Name:** `packet_transmission_mode`
+- **Description:** Identifies the JPEG XS packetization and transmission mode.
+- **Specification:** [RFC 9134][RFC-9134]
+- **Applicability:** `urn:x-nmos:transport:rtp`
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.3, string values representing the valid combinations of the transmission mode (T) bit and packetization mode (K) bit, as enumerated in the schema accompanying this register
+    - `codestream` (T=1, K=0)
+    - `slice_sequential` (T=1, K=1)
+    - `slice_out_of_order` (T=0, K=1)
+  - When the attribute is omitted, a JPEG XS Sender is assumed to be using the `codestream` packetization mode
+
 ### ST 2110-21 Sender Type
 - **Name:** `st2110_21_sender_type`
 - **Description:** Identifies the traffic shaping and delivery timing requirements of ST 2110-21 to which the Sender complies.
@@ -46,3 +58,5 @@ These MAY be used in addition to the schema, _sender.json_, found in the AMWA IS
     - `2110TPN`
     - `2110TPNL`
     - `2100TPW`
+
+[RFC-9134]: https://tools.ietf.org/html/rfc9134 "RTP Payload Format for ISO/IEC 21122 (JPEG XS)"

--- a/sender-attributes/sender_register.json
+++ b/sender-attributes/sender_register.json
@@ -8,6 +8,16 @@
       "description": "Bit rate, in kilobits/second. Integer value expressed in units of 1000 bits per second, rounding up.",
       "type": "integer"
     },
+    "packet_transmission_mode": {
+      "description": "JPEG XS packetization and transmission mode. String value representing the valid combinations of the transmission mode (T) bit and packetization mode (K) bit.",
+      "type": "string",
+      "enum": [
+        "codestream",
+        "slice_sequential",
+        "slice_out_of_order"
+      ],
+      "default": "codestream"
+    },
     "st2110_21_sender_type": {
       "description": "ST 2110-21 Sender Type. Indicates the traffic shaping and delivery timing requirements of ST 2110-21 to which the Sender complies.",
       "type": "string",


### PR DESCRIPTION
A Sender attribute and related Receiver caps parameter constraint, corresponding to RFC 9134 `packetmode` and `transmode`.