### PR TITLE
Update tr-09-2.md to reflect changes in VSF TR-09-2

### DIFF
--- a/tags/tr-09-2.md
+++ b/tags/tr-09-2.md
@@ -47,8 +47,9 @@ Several examples are given below.
 The colon character, `:`, is reserved and MUST NOT be used in any of the parameters listed.
 
 As defined in the VSF TR-09-2 specification:
-- The `consumer-id` SHOULD be provided by the facility *offering* the shared resource.
-- The `booking-id`, `element-id` and `label` SHOULD be provided by the facility *consuming* the shared resource.
+- The `consumer-id` and `element-id` MUST be provided by the facility *offering* the shared resource.
+- The `booking-id` MUST be provided by the facility *consuming* the shared resource.
+- The optional `label` SHOULD be provided by the facility *consuming* the shared resource.
 - The `element-id` MUST be unique within a booking (as identified by `<consumer-id>:<booking-id>`).
 - The `element-id` SHOULD NOT be the same as the NMOS UUID associated with the resource (from the resource's `id` field).
 - The same `element-id` MAY be used for a given resource across multiple bookings.


### PR DESCRIPTION
Two updates to reflect changes to VSF TR-09-2: 
1. Offering facility (not receiving facility) is now responsible for defining element-id. 
2. We cannot leave it up to implementations to decide which facility defines the consumer-id, booking-id and element-id, so SHOULDs have been changed to MUSTs.