### PR TITLE
flow-attributes: move ST2115LOGS3 from colorspace to TCS

### DIFF
--- a/flow-attributes/flow_video_base_register.json
+++ b/flow-attributes/flow_video_base_register.json
@@ -20,8 +20,7 @@
         "ST2065-3",
         "UNSPECIFIED",
         "XYZ",
-        "ALPHA",
-        "ST2115LOGS3"
+        "ALPHA"
       ]
     },
     "components" : {
@@ -101,6 +100,7 @@
         "ST2065-1",
         "ST428-1",
         "DENSITY",
+        "ST2115LOGS3",
         "UNSPECIFIED"
       ]
     }


### PR DESCRIPTION
The flow_video_base_register.json schema defines `ST2115LOGS3` as a value of the `colorspace` attribute, but it should be a value of the `transfer_characteristic` attribute.