### PR TITLE
Add capabilities and attributes for BCP-006-02 and BCP-006-03 as required by IPMX HEVC and H.264 codec

### DIFF
--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -155,6 +155,14 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
   - **Target:** coded video or audio Flow `bit_rate` (defined in the [Flow Attributes](../flow-attributes/README.md#bit-rate) register)
 - **Applicability:** AMWA IS-04
 
+### Format Constant Bit Rate
+- **Name:** `urn:x-nmos:cap:format:constant_bit_rate`
+- **Description:** Identifies the acceptable bit rate mode (constant or variable) of a compressed video or audio stream.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** boolean
+  - **Target:** coded video or audio Flow `constant_bit_rate` (defined in the [Flow Attributes](../flow-attributes/README.md#constant-bit-rate) register)
+- **Applicability:** AMWA IS-04
+
 ### Profile
 - **Name:** `urn:x-nmos:cap:format:profile`
 - **Description:** Identifies the acceptable profiles, as defined for the specific media type.
@@ -237,10 +245,10 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
 
 ### Packet Transmission Mode
 - **Name:** `urn:x-nmos:cap:transport:packet_transmission_mode`
-- **Description:** Identifies the acceptable JPEG XS packetization and transmission mode.
+- **Description:** Identifies the acceptable packet transmission mode.
 - **Specification:** per AMWA BCP-004-01
-  - **Type:** string (enumerated values as per the [Sender Attributes](../sender-attributes/README.md#packet-transmission-mode) register)
-  - **Target:** (a) Sender `packet_transmission_mode` (defined in the Sender Attributes register), (b) SDP attribute `a=fmtp:` format-specific parameters `packetmode` and `transmode`, per [RFC 9134][RFC-9134]
+  - **Type:** string (enumerated values as per the [Sender Attributes](../sender-attributes/README.md#packet-transmission-mode), [H.264 Sender Attributes](../sender-h264-attributes/README.md#packet-transmission-mode), [H.265 Sender Attributes](../sender-h265-attributes/README.md#packet-transmission-mode) registers)
+  - **Target:** (a) Sender `packet_transmission_mode` (defined in the Sender Attributes register), (b) SDP attribute `a=fmtp:` format-specific parameters `packetmode` and `transmode`, per [RFC 9134][RFC-9134], (c) SDP attribute `a=fmtp:` format-specific parameter `packetization-mode`, per [RFC 6184][RFC-6184], (d) SDP attribute `a=fmtp:` format-specific parameter `sprop-max-don-diff`, per [RFC 7798][RFC-7798]
 - **Applicability:** AMWA IS-04
 
 ### ST 2110-21 Sender Type
@@ -259,6 +267,24 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
   - **Target:** (a) Sender `hkep` attribute, (b) SDP attribute `a=hkep:`
 - **Applicability:** AMWA IS-04
 
+### Parameter Sets Transport Mode
+- **Name:** `urn:x-nmos:cap:transport:parameter_sets_transport_mode`
+- **Description:** Identifies the acceptable parameter sets transport modes.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per the [H.264 Sender Attributes](../sender-h264-attributes/README.md#parameter-sets-transport-mode), [H.265 Sender Attributes](../sender-h265-attributes/README.md#parameter-sets-transport-mode) registers)
+  - **Target:** (a) Sender `parameter_sets_transport_mode` (defined in the Sender Attributes register), (b) SDP attribute `a=fmtp:` format-specific parameter `sprop-parameter-sets`, per [RFC 6184][RFC-6184], (c) SDP attribute `a=fmtp:` format-specific parameters `sprop-vps`, `sprop-sps` and `sprop-pps`, per [RFC 7798][RFC-7798]
+- **Applicability:** AMWA IS-04
+
+### Parameter Sets Flow Mode
+- **Name:** `urn:x-nmos:cap:transport:parameter_sets_flow_mode`
+- **Description:** Identifies the acceptable parameter sets flow modes.
+- **Specification:** per AMWA BCP-004-01
+  - **Type:** string (enumerated values as per the [H.264 Sender Attributes](../sender-h264-attributes/README.md#parameter-sets-transport-mode), [H.265 Sender Attributes](../sender-h265-attributes/README.md#parameter-sets-transport-mode) registers)
+  - **Target:** (a) Sender `parameter_sets_flow_mode` (defined in the Sender Attributes register)
+- **Applicability:** AMWA IS-04
+
 [RFC-4566]: https://tools.ietf.org/html/rfc4566 "SDP: Session Description Protocol"
 [RFC-9134]: https://tools.ietf.org/html/rfc9134 "RTP Payload Format for ISO/IEC 21122 (JPEG XS)"
+[RFC-6184]: https://tools.ietf.org/html/rfc6184 "RTP Payload Format for H.264 Video"
+[RFC-7798]: https://tools.ietf.org/html/rfc7798 "RTP Payload Format for High Efficiency Video Coding (HEVC)"
 [color-sampling]: https://www.iana.org/assignments/media-type-sub-parameters/media-type-sub-parameters.xhtml#media-type-sub-parameters-15 "Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling"

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -247,7 +247,7 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
 - **Name:** `urn:x-nmos:cap:transport:packet_transmission_mode`
 - **Description:** Identifies the acceptable packet transmission mode.
 - **Specification:** per AMWA BCP-004-01
-  - **Type:** string (enumerated values as per the [Sender Attributes](../sender-attributes/README.md#packet-transmission-mode), [H.264 Sender Attributes](../sender-h264-attributes/README.md#packet-transmission-mode), [H.265 Sender Attributes](../sender-h265-attributes/README.md#packet-transmission-mode) registers)
+  - **Type:** string (enumerated values as per the [Sender Attributes](../sender-attributes/README.md#packet-transmission-mode), [H.264 Sender Attributes](../sender-attributes/README.md#packet-transmission-mode), [H.265 Sender Attributes](../sender-attributes/README.md#packet-transmission-mode) registers)
   - **Target:** (a) Sender `packet_transmission_mode` (defined in the Sender Attributes register), (b) SDP attribute `a=fmtp:` format-specific parameters `packetmode` and `transmode`, per [RFC 9134][RFC-9134], (c) SDP attribute `a=fmtp:` format-specific parameter `packetization-mode`, per [RFC 6184][RFC-6184], (d) SDP attribute `a=fmtp:` format-specific parameter `sprop-max-don-diff`, per [RFC 7798][RFC-7798]
 - **Applicability:** AMWA IS-04
 
@@ -271,7 +271,7 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
 - **Name:** `urn:x-nmos:cap:transport:parameter_sets_transport_mode`
 - **Description:** Identifies the acceptable parameter sets transport modes.
 - **Specification:** per AMWA BCP-004-01
-  - **Type:** string (enumerated values as per the [H.264 Sender Attributes](../sender-h264-attributes/README.md#parameter-sets-transport-mode), [H.265 Sender Attributes](../sender-h265-attributes/README.md#parameter-sets-transport-mode) registers)
+  - **Type:** string (enumerated values as per the [H.264 Sender Attributes](../sender-attributes/README.md#parameter-sets-transport-mode), [H.265 Sender Attributes](../sender-attributes/README.md#parameter-sets-transport-mode) registers)
   - **Target:** (a) Sender `parameter_sets_transport_mode` (defined in the Sender Attributes register), (b) SDP attribute `a=fmtp:` format-specific parameter `sprop-parameter-sets`, per [RFC 6184][RFC-6184], (c) SDP attribute `a=fmtp:` format-specific parameters `sprop-vps`, `sprop-sps` and `sprop-pps`, per [RFC 7798][RFC-7798]
 - **Applicability:** AMWA IS-04
 
@@ -279,7 +279,7 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
 - **Name:** `urn:x-nmos:cap:transport:parameter_sets_flow_mode`
 - **Description:** Identifies the acceptable parameter sets flow modes.
 - **Specification:** per AMWA BCP-004-01
-  - **Type:** string (enumerated values as per the [H.264 Sender Attributes](../sender-h264-attributes/README.md#parameter-sets-transport-mode), [H.265 Sender Attributes](../sender-h265-attributes/README.md#parameter-sets-transport-mode) registers)
+  - **Type:** string (enumerated values as per the [H.264 Sender Attributes](../sender-attributes/README.md#parameter-sets-transport-mode), [H.265 Sender Attributes](../sender-attributes/README.md#parameter-sets-transport-mode) registers)
   - **Target:** (a) Sender `parameter_sets_flow_mode` (defined in the Sender Attributes register)
 - **Applicability:** AMWA IS-04
 

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -48,6 +48,9 @@
     "urn:x-nmos:cap:format:bit_rate": {
       "$ref": "param_constraint_integer.json"
     },
+    "urn:x-nmos:cap:format:constant_bit_rate": {
+      "$ref": "param_constraint_integer.json"
+    },
     "urn:x-nmos:cap:format:profile": {
       "$ref": "param_constraint_string.json"
     },
@@ -82,6 +85,12 @@
       "$ref": "param_constraint_string.json"
     },
     "urn:x-nmos:cap:transport:st2110_21_sender_type": {
+      "$ref": "param_constraint_string.json"
+    },
+    "urn:x-nmos:cap:transport:parameter_sets_transport_mode": {
+      "$ref": "param_constraint_string.json"
+    },
+    "urn:x-nmos:cap:transport:parameter_sets_flow_mode": {
       "$ref": "param_constraint_string.json"
     },
     "urn:x-nmos:cap:transport:hkep": {

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -49,7 +49,7 @@
       "$ref": "param_constraint_integer.json"
     },
     "urn:x-nmos:cap:format:constant_bit_rate": {
-      "$ref": "param_constraint_integer.json"
+      "$ref": "param_constraint_boolean.json"
     },
     "urn:x-nmos:cap:format:profile": {
       "$ref": "param_constraint_string.json"

--- a/flow-attributes/README.md
+++ b/flow-attributes/README.md
@@ -28,11 +28,19 @@ These MAY be used in addition to the schemas, such as _flow_video.json_ and _flo
 
 ### Bit Rate
 - **Name:** `bit_rate`
-- **Description:** Target bit rate of the codestream, in kilobits/second.
-- **Specification:** [AMWA BCP-006-01](https://specs.amwa.tv/bcp-006-01/v1.0)
+- **Description:** Target bit rate of the codestream/bitstream, in kilobits/second.
+- **Specification:** [AMWA BCP-006-01](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
 - **Applicability:** `urn:x-nmos:format:video` or `urn:x-nmos:format:audio`
 - **Permitted Values:**
   - Since AMWA IS-04 v1.3, integer values expressed in units of 1000 bits per second, rounding up
+
+### Constant Bit Rate
+- **Name:** `constant_bit_rate`
+- **Description:**  Indicates that the Flow is constant or variable bit rate.
+- **Specification:** [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
+- **Applicability:** `urn:x-nmos:format:video` or `urn:x-nmos:format:audio`
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.3, boolean values true or false.
 
 ### Colorspace
 - **Name:** `colorspace`
@@ -74,24 +82,36 @@ These MAY be used in addition to the schemas, such as _flow_video.json_ and _flo
 ### Level
 - **Name:** `level`
 - **Description:** Indicates constraints on parameters of the coding tools that are in use, as defined for the Flow media type.
-- **Specification:** [AMWA BCP-006-01](https://specs.amwa.tv/bcp-006-01/v1.0)
-- **Applicability:** `urn:x-nmos:format:video`
+- **Specification:** [AMWA BCP-006-01](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
+- **Applicability:** `urn:x-nmos:format:video` or `urn:x-nmos:format:audio`
 - **Permitted Values:**
   - Since AMWA IS-04 v1.3, string values defined for the Flow media type, as enumerated in the schema accompanying this register
   - For `video/jxsv`, the values are the level names defined by ISO/IEC 21122-2, with any white space Unicode characters omitted as per [RFC 9134][RFC-9134]
   - For example
     - `1k-1`
+  - For `video/H264`, the values are the level names defined by Rec. ITU-T H.264 Annex A.
+    - For example
+      - `5.1`
+  - For `video/H265`, the values are the level names defined Rec. ITU-T H.265 Annex A where the tier name prefixes the level number.
+    - For example
+      - `Main-5.1`
 
 ### Profile
 - **Name:** `profile`
 - **Description:** Indicates the subset of coding tools that are in use, as defined for the Flow media type.
-- **Specification:** [AMWA BCP-006-01](https://specs.amwa.tv/bcp-006-01/v1.0)
-- **Applicability:** `urn:x-nmos:format:video`
+- **Specification:** [AMWA BCP-006-01](https://specs.amwa.tv/bcp-006-01/v1.0),  [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
+- **Applicability:** `urn:x-nmos:format:video` or `urn:x-nmos:format:audio`
 - **Permitted Values:**
   - Since AMWA IS-04 v1.3, string values defined for the Flow media type, as enumerated in the schema accompanying this register
   - For `video/jxsv`, the values are the profile names defined by ISO/IEC 21122-2, with any white space Unicode characters omitted as per [RFC 9134][RFC-9134]
   - For example
     - `Main444.12`
+  - For `video/H264`, the values are the profile names defined by Rec. ITU-T H.264 Annex A, with whitespace omitted, the sampling mode always positioned at the end of the string, preceded by a '-' and the terms High and Baseline positioned at the beginning of the string.
+    - For example
+      - `High-422`
+  - For `video/H265`, the values are the profile names defined by Rec. ITU-T H.265 Annex A, with whitespace omitted and the sampling mode always positioned at the end of the string, preceded by a '-'.
+    - For example
+      - `Main12-422`
 
 ### Sublevel
 - **Name:** `sublevel`

--- a/flow-attributes/flow_data_register.json
+++ b/flow-attributes/flow_data_register.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes Data Flow additional and extensible attributes defined in the NMOS Parameter Registers.",
+  "title": "Data Flow resource",
+  "properties": {
+  }
+}

--- a/flow-attributes/flow_video_base_register.json
+++ b/flow-attributes/flow_video_base_register.json
@@ -87,6 +87,10 @@
       "description": "Sublevel. Indicates additional constraints on parameters of the coding tools that are in use, as defined for the Flow media type. For example, in the case of JPEG XS, the level indicates constraints in the decoded image domain, and the sublevel indicates constraints in the encoded image domain.",
       "type": "string"
     },
+    "constant_bit_tate": {
+      "description": "Constant bit rate. Indicates that the Flow is constant or variable bit rate.",
+      "type": "boolean"
+    },
     "transfer_characteristic": {
       "description": "Transfer characteristic. Values defined for the TCS format-specific parameter in any published revision of SMPTE ST 2110-20.",
       "type": "string",

--- a/flow-attributes/flow_video_h264_register.json
+++ b/flow-attributes/flow_video_h264_register.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes Video Flow constraints specific to H.264 defined in the NMOS Parameter Registers.",
+  "title": "Video Flow resource",
+  "properties": {
+    "level": {
+      "description": "Level. Indicates constraints on parameters of the coding tools that are in use, as defined for the Flow media type.",
+      "type": "string",
+      "enum": [
+        "1",
+        "1b", "1.1", "1.2", "1.3",
+        "2", "2.1", "2.2",
+        "3", "3.1", "3.2",
+        "4", "4.1", "4.2",
+        "5", "5.1", "5.2",
+        "6", "6.1", "6.2"
+      ]
+    },
+    "profile": {
+      "description": "Profile. Indicates the subset of coding tools that are in use, as defined for the Flow media type.",
+      "type": "string",
+      "enum": [
+        "BaselineConstrained",
+        "Baseline",
+        "Main",
+        "Extended",
+        "High", "High-422",
+        "HighProgressive",
+        "HighConstrained",
+        "High10",
+        "High10Progressive",
+        "HighPredictive-444",
+        "High10Intra",
+        "HighIntra-422", "HighIntra-444",
+        "CAVLCIntra-444"
+      ]
+    },
+    "constant_bit_rate": {
+      "description": "Constant bit rate. Indicates that the Flow is constant or variable bit rate.",
+      "type": "boolean",
+      "enum": [
+        true, false
+      ]
+    }
+  }
+}

--- a/flow-attributes/flow_video_h265_register.json
+++ b/flow-attributes/flow_video_h265_register.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes Video Flow constraints specific to H.264 defined in the NMOS Parameter Registers.",
+  "title": "Video Flow resource",
+  "properties": {
+    "level": {
+      "description": "Level. Indicates constraints on parameters of the coding tools that are in use, as defined for the Flow media type.",
+      "type": "string",
+      "enum": [
+        "Main-1",
+        "Main-2", "Main-2.1",
+        "Main-3",
+        "Main-3.1",
+        "Main-4", "Main-4.1",
+        "Main-5", "Main-5.1", "Main-5.2",
+        "Main-6", "Main-6.1", "Main-6.2",
+        "High-4", "High-4.1",
+        "High-5", "High-5.1", "High-5.2",
+        "High-6", "High-6.1", "High-6.2",
+        "High-8.5"
+      ]
+    },
+    "profile": {
+      "description": "Profile. Indicates the subset of coding tools that are in use, as defined for the Flow media type.",
+      "type": "string",
+      "enum": [
+        "Main", "Main-444",
+        "MainStillPicture", "MainStillPicture-444",
+        "Main10StillPicture",
+        "Main16StillPicture-444",
+        "Main10", "Main10-422", "Main10-444",
+        "Main12", "Main12-422", "Main12-444",
+        "MainIntra", "MainIntra-444",
+        "Main10Intra", "Main10Intra-422", "Main10Intra-444",
+        "Main12Intra", "Main12Intra-422", "Main12Intra-444",
+        "Main16Intra-444",
+        "Monochrome",
+        "Monochrome10",
+        "Monochrome12",
+        "Monochrome16",
+        "HighThroughput-444",
+        "HighThroughput10-444",
+        "HighThroughput14-444",
+        "HighThroughput16Intra-444",
+        "ScreenExtendedMain","ScreenExtendedMain-444",
+        "ScreenExtendedMain10", "ScreenExtendedMain10-444",
+        "ScreenExtendedHighThroughput-444",
+        "ScreenExtendedHighThroughput10-444",
+        "ScreenExtendedHighThroughput14-444"
+      ]
+    },
+    "constant_bit_rate": {
+      "description": "Constant bit rate. Indicates that the Flow is constant or variable bit rate.",
+      "type": "boolean",
+      "enum": [
+        true, false
+      ]
+    }
+  }
+}

--- a/flow-attributes/flow_video_register.json
+++ b/flow-attributes/flow_video_register.json
@@ -10,6 +10,18 @@
         { "not": { "properties": { "media_type": { "enum": [ "video/jxsv" ] } } } },
         { "$ref": "flow_video_jxsv_register.json" }
       ]
+    },
+    {
+      "anyOf": [
+        { "not": { "properties": { "media_type": { "enum": [ "video/H264" ] } } } },
+        { "$ref": "flow_video_h264_register.json" }
+      ]
+    },
+    {
+      "anyOf": [
+        { "not": { "properties": { "media_type": { "enum": [ "video/H265" ] } } } },
+        { "$ref": "flow_video_h265_register.json" }
+      ]
     }
   ]
 }

--- a/sender-attributes/README.md
+++ b/sender-attributes/README.md
@@ -62,7 +62,7 @@ as enumerated in the schema accompanying this register
 ### ST 2110-21 Sender Type
 - **Name:** `st2110_21_sender_type`
 - **Description:** Identifies the traffic shaping and delivery timing requirements of ST 2110-21 to which the Sender complies.
-- **Specification:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03]
+- **Specification:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
 - **Applicability:** `urn:x-nmos:transport:rtp`
 - **Permitted Values:**
   - Since AMWA IS-04 v1.3, values defined for the TP format-specific parameter in any published revision of SMPTE ST 2110-21

--- a/sender-attributes/README.md
+++ b/sender-attributes/README.md
@@ -29,7 +29,7 @@ These MAY be used in addition to the schema, _sender.json_, found in the AMWA IS
 ### Bit Rate
 - **Name:** `bit_rate`
 - **Description:** Bit rate, in kilobits/second, including the transport overhead.
-- **Specifications:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-04 v1.0](https://specs.amwa.tv/bcp-006-04/v1.0)
+- **Specifications:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-04 v1.0](https://specs.amwa.tv/bcp-006-04/v1.0), [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
 - **Applicability:** `urn:x-nmos:transport:rtp`
 - **Permitted Values:**
   - Since AMWA IS-04 v1.3, integer values expressed in units of 1000 bits per second, rounding up
@@ -38,19 +38,31 @@ These MAY be used in addition to the schema, _sender.json_, found in the AMWA IS
 ### Packet Transmission Mode
 - **Name:** `packet_transmission_mode`
 - **Description:** Identifies the JPEG XS packetization and transmission mode.
-- **Specification:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0)
+- **Specification:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
 - **Applicability:** `urn:x-nmos:transport:rtp`
 - **Permitted Values:**
-  - Since AMWA IS-04 v1.3, string values representing the valid combinations of the [RFC 9134][RFC-9134] transmission mode (T) bit and packetization mode (K) bit, as enumerated in the schema accompanying this register
+  - Since AMWA IS-04 v1.3, string values defined for the Flow media type, as enumerated in the schema accompanying this register
+  - For `video/jxsv` string values representing the valid combinations of the [RFC 9134][RFC-9134] transmission mode (T) bit and packetization mode (K) bit, as enumerated in the schema accompanying this register
     - `codestream` (T=1, K=0)
     - `slice_sequential` (T=1, K=1)
     - `slice_out_of_order` (T=0, K=1)
-  - When the attribute is omitted, a JPEG XS Sender is assumed to be using the `codestream` packetization mode
+  - When the attribute is omitted, a JPEG XS Sender is assumed to be using the `codestream` packet transmission mode
+  - For `video/H264` string values representing the valid packetization-mode of [RFC 6184][RFC-6184] 
+as enumerated in the schema accompanying this register
+    - `single_nal_unit` (value 0)
+    - `non_interleaved_nal_units` (value 1)
+    - `interleaved_nal_units` (value 2)
+  - When the attribute is omitted, a H.264 Sender is assumed to be using the `single_nal_unit` packet transmission mode
+  - For `video/H265` string values representing the value sprop-max-don-diff of [RFC 7798][RFC-7798] 
+as enumerated in the schema accompanying this register
+    - `non_interleaved_nal_units` (value 0)
+    - `interleaved_nal_units` (value greater than 0)
+  - When the attribute is omitted, a H.265 Sender is assumed to be using the `non_interleaved_nal_units` packet transmission mode
 
 ### ST 2110-21 Sender Type
 - **Name:** `st2110_21_sender_type`
 - **Description:** Identifies the traffic shaping and delivery timing requirements of ST 2110-21 to which the Sender complies.
-- **Specification:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0)
+- **Specification:** [AMWA BCP-006-01 v1.0](https://specs.amwa.tv/bcp-006-01/v1.0), [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03]
 - **Applicability:** `urn:x-nmos:transport:rtp`
 - **Permitted Values:**
   - Since AMWA IS-04 v1.3, values defined for the TP format-specific parameter in any published revision of SMPTE ST 2110-21
@@ -67,4 +79,30 @@ These MAY be used in addition to the schema, _sender.json_, found in the AMWA IS
 - **Permitted Values:**
   - Since AMWA IS-04 v1.3, boolean `true`, `false`
 
+### Parameter Sets Transport Mode
+- **Name:** `parameter_sets_transport_mode`
+- **Description:** Identifies the codec parameter sets transport mode.
+- **Specification:** [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
+- **Applicability:** `urn:x-nmos:transport:rtp` (when media_type is not `video/MP2T`)
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.3, string values defined for the Flow media type, as enumerated in the schema accompanying this register
+- For `video/H264` or `video/H265` string values representing the valid parameter sets flow as enumerated in the schema accompanying this register
+  - `strict`
+  - `static`
+  - `dynamic`
+
+### Parameter Sets Flow Mode
+- **Name:** `parameter_sets_flow_mode`
+- **Description:** Identifies the codec parameter sets flow mode.
+- **Specification:** [AMWA BCP-006-02](https://specs.amwa.tv/bcp-006-02/v1.0), [AMWA BCP-006-03](https://specs.amwa.tv/bcp-006-03/v1.0)
+- **Applicability:** `urn:x-nmos:transport:rtp` (when media_type is not `video/MP2T`)
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.3, string values defined for the Flow media type, as enumerated in the schema accompanying this register
+- For `video/H264` or `video/H265` string values representing the valid parameter sets flow as enumerated in the schema accompanying this register
+  - `in_band`
+  - `out_of_band`
+  - `in_and_out_of_band`
+
 [RFC-9134]: https://tools.ietf.org/html/rfc9134 "RTP Payload Format for ISO/IEC 21122 (JPEG XS)"
+[RFC-6184]: https://tools.ietf.org/html/rfc6184 "RTP Payload Format for H.264 Video"
+[RFC-7798]: https://tools.ietf.org/html/rfc7798 "RTP Payload Format for High Efficiency Video Coding (HEVC)"

--- a/sender-attributes/sender_h264_register.json
+++ b/sender-attributes/sender_h264_register.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes Sender additional and extensible attributes defined in the NMOS Parameter Registers.",
+  "title": "Sender resource",
+  "allOf": [
+    { "$ref": "sender_h26x_register.json" },
+    {
+      "type": "object",
+      "description": "Describes Video Flow constraints specific to H.264 defined in the NMOS Parameter Registers.",
+      "title": "Sender resource",
+      "properties": {
+        "packet_transmission_mode": {
+          "description": "H.264 packetization and transmission mode.",
+          "type": "string",
+          "enum": [
+            "non_interleaved_nal_units",
+            "interleaved_nal_units",
+            "single_nal_unit"
+          ],
+          "default": "single_nal_unit"
+        }
+      }
+    }
+  ]
+}

--- a/sender-attributes/sender_h265_register.json
+++ b/sender-attributes/sender_h265_register.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes Sender additional and extensible attributes defined in the NMOS Parameter Registers.",
+  "title": "Sender resource",
+  "allOf": [
+    { "$ref": "sender_h26x_register.json" },
+    {
+      "type": "object",
+      "description": "Describes Video Flow constraints specific to H.265 defined in the NMOS Parameter Registers.",
+      "title": "Sender resource",
+      "properties": {
+        "packet_transmission_mode": {
+          "description": "H.265 packetization and transmission mode.",
+          "type": "string",
+          "enum": [
+            "non_interleaved_nal_units",
+            "interleaved_nal_units"
+          ],
+          "default": "non_interleaved_nal_units"
+        }
+      }
+    }
+  ]
+}

--- a/sender-attributes/sender_h26x_register.json
+++ b/sender-attributes/sender_h26x_register.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes Sender additional and extensible attributes defined in the NMOS Parameter Registers.",
+  "title": "Sender resource",
+  "properties": {
+    "bit_rate": {
+      "description": "Bit rate, in kilobits/second. Integer value expressed in units of 1000 bits per second, rounding up.",
+      "type": "integer"
+    },
+    "st2110_21_sender_type": {
+      "description": "ST 2110-21 Sender Type. Indicates the traffic shaping and delivery timing requirements of ST 2110-21 to which the Sender complies.",
+      "type": "string",
+      "enum": [
+        "2110TPN",
+        "2110TPNL",
+        "2110TPW"
+      ]
+    },
+    "parameter_sets_flow_mode": {
+      "description": "H.264 / H.265 parameter sets flow mode.",
+      "type": "string",
+      "enum": [
+        "strict",
+        "static",
+        "dynamic"
+      ],
+      "default": "dynamic"
+    },
+    "parameter_sets_transport_mode": {
+      "description": "H.264 / H.265 parameter sets transport mode.",
+      "type": "string",
+      "enum": [
+        "in_band",
+        "out_of_band",
+        "in_and_out_of_band"
+      ],
+      "default": "in_band"
+    }
+  }
+}


### PR DESCRIPTION
The IPMX test suite requires the capabilities and attributes of BCP-006-02 and BCP-006-03 to be present in the NMOS Parameter Registers. Those are required for testing and implementing IPMX HEVC and H.264 codec in the standard x-nmos namespace.