### PR TITLE
Update the Parameter Registers for BCP-007-02 

### DIFF
--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -259,6 +259,15 @@ It MAY be used in place of the file with the same name in the AMWA BCP-004-01 sp
   - **Target:** (a) Sender `hkep` attribute, (b) SDP attribute `a=hkep:`
 - **Applicability:** AMWA IS-04
 
+### USB Class
+- **Name:** `urn:x-nmos:cap:transport:usb_class`
+- **Description:** Indicates the USB classes supported.
+- **Specification:** per AMWA BCP-007-02
+  - **Type:** integer in the range 0 to 255
+  - **Target:** (a) Sender `urn:x-nmos:cap:transport:usb_class` capability, (b) Source `usb_devices` attribute when present.
+- **Applicability:** AMWA IS-04
+
+
 [RFC-4566]: https://tools.ietf.org/html/rfc4566 "SDP: Session Description Protocol"
 [RFC-9134]: https://tools.ietf.org/html/rfc9134 "RTP Payload Format for ISO/IEC 21122 (JPEG XS)"
 [color-sampling]: https://www.iana.org/assignments/media-type-sub-parameters/media-type-sub-parameters.xhtml#media-type-sub-parameters-15 "Media Type Sub-Parameter Registry for video/raw: Color (sub-)sampling"

--- a/capabilities/constraint_set.json
+++ b/capabilities/constraint_set.json
@@ -86,6 +86,9 @@
     },
     "urn:x-nmos:cap:transport:hkep": {
       "$ref": "param_constraint_boolean.json"
+    },
+    "urn:x-nmos:cap:transport:usb_class": {
+      "$ref": "param_constraint_integer.json"
     }
   },
   "patternProperties": {

--- a/flow-attributes/flow_data_register.json
+++ b/flow-attributes/flow_data_register.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes Data Flow additional and extensible attributes defined in the NMOS Parameter Registers.",
+  "title": "Data Flow resource",
+  "properties": {
+  }
+}

--- a/source-attributes/README.md
+++ b/source-attributes/README.md
@@ -25,3 +25,11 @@ Query APIs and their clients which support v1.3 of IS-04 or operate in a mixed-v
 
 Note: JSON schemas supporting validation of all the attributes will be defined in this register.
 These MAY be used in addition to the schemas, such as _source_generic.json_ and _source_audio.json_, found in the AMWA IS-04 specification.
+
+### USB Devices
+- **Name:** `usb_devices`
+- **Description:** Describes the USB devices accessible to a Receiver via the USB data stream.
+- **Specification:** [AMWA BCP-007-02 v1.0](https://specs.amwa.tv/bcp-007-02)
+- **Applicability:** `urn:x-nmos:transport:usb`
+- **Permitted Values:**
+  - Since AMWA IS-04 v1.3, Array of `usb_device` objects 

--- a/source-attributes/README.md
+++ b/source-attributes/README.md
@@ -32,4 +32,4 @@ These MAY be used in addition to the schemas, such as _source_generic.json_ and 
 - **Specification:** [AMWA BCP-007-02 v1.0](https://specs.amwa.tv/bcp-007-02)
 - **Applicability:** `urn:x-nmos:transport:usb`
 - **Permitted Values:**
-  - Since AMWA IS-04 v1.3, Array of `usb_device` objects 
+  - Since AMWA IS-04 v1.3, Array of `usb_device` objects

--- a/source-attributes/source_register.json
+++ b/source-attributes/source_register.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "description": "Describes the Source additional and extensible attributes defined in the NMOS Parameter Registers.",
+    "title": "Source resource",
+    "properties": {
+        "usb_devices": {
+            "description": "Describes the USB devices accessible to a Receiver via the USB data stream.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "title": "USB Class",
+                "properties": {
+                    "ipmx_bus_id": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 255
+                        },
+                        "minItems": 64,
+                        "maxItems": 64,
+                        "description": "IPMX USB UTF-8 BUSID 64-byte value"
+                    },
+                    "class": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 255
+                        },
+                        "description": "Device class or classes if a composite device"
+                    },
+                    "vendor": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "description": "Vendor ID"
+                    },
+                    "product": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "description": "Product ID"
+                    },
+                    "serial": {
+                        "type": "string",
+                        "description": "Serial number"
+                    }
+                },
+                "required": [
+                    "ipmx_bus_id",
+                    "class",
+                    "vendor",
+                    "product",
+                    "serial"
+                ]
+            }
+        }
+    }
+}

--- a/transports/README.md
+++ b/transports/README.md
@@ -73,3 +73,10 @@ Note: The IS-05 v1.1 `/transporttype` endpoint returns the URN base; the subclas
 - **Specification:** [AMWA BCP-007-01](https://specs.amwa.tv/bcp-007-01/)
 - **Schemas:** [AMWA BCP-007-01 (schemas)](https://specs.amwa.tv/bcp-007-01/branches/v1.0-dev/APIs/schemas/)
 - **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.2, BCP-007-01 since v1.0
+
+### USB
+- **Name:** `urn:x-nmos:transport:usb`
+- **Description:** Identifies the IPMX/USB transport type.
+- **Specification:** [AMWA BCP-007-02](https://specs.amwa.tv/bcp-007-02/)
+- **Schemas:** [AMWA BCP-007-02 (schemas)](https://specs.amwa.tv/bcp-007-02/branches/v1.0-dev/APIs/schemas/)
+- **Applicability:** AMWA IS-04 since v1.3, IS-05 since v1.2, BCP-007-02 since v1.0


### PR DESCRIPTION
Update the Parameter Registers for BCP-005-03:

add transport:usb_class capability
add flow_data_register.json to get a valid schema for data flows
add usb_devices source attribute
add urn:x-nmos:transport:usb that was supposed to go with bcp-005-03

